### PR TITLE
fix/AdguardFilters#16648

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -24,6 +24,8 @@ $popup,~third-party
 !
 adguard
 ! 
+! https://github.com/AdguardTeam/AdguardFilters/issues/16648
+$rewrite=
 ! https://github.com/AdguardTeam/AdguardFilters/issues/8172
 @@||investopedia.com^$elemhide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7371


### PR DESCRIPTION
Excluded unsupported `$rewrite=` rules https://github.com/AdguardTeam/AdguardFilters/issues/16648