### PR TITLE
updated compiler - content blockers omit extended css

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Adguard filters compiler",
   "homepage": "http://adguard.com",
   "dependencies": {
-    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#dd0a88f"
+    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#85dafff"
   },
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Extended Css rules are now skipped for content-blocker platforms