### PR TITLE
Change SDNS filter source

### DIFF
--- a/filters/filter_15_DnsFilter/template.txt
+++ b/filters/filter_15_DnsFilter/template.txt
@@ -1,2 +1,2 @@
 !
-@include "https://adguardteam.github.io/AdguardDNS/Filters/filter.txt"
+@include "https://adguardteam.github.io/AdguardSDNSFilter/Filters/filter.txt"

--- a/filters/filter_15_DnsFilter/template.txt
+++ b/filters/filter_15_DnsFilter/template.txt
@@ -1,2 +1,2 @@
 !
-@include "https://adguardteam.github.io/AdguardSDNSFilter/Filters/filter.txt"
+@include "https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt"


### PR DESCRIPTION
Guys, we're going to host AdGuard DNS code in the old location so the SDNS filter has a new location now:
https://github.com/AdguardTeam/AdGuardSDNSFilter

