### PR TITLE
Use fork of Juvander's list

### DIFF
--- a/filters/ThirdParty/filter_233_AdblockListFinland/metadata.json
+++ b/filters/ThirdParty/filter_233_AdblockListFinland/metadata.json
@@ -7,7 +7,7 @@
   "expires": "2 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "https://adb.theel0ja.info/finnish-easylist-addition/Finland_adb.txt",
+  "subscriptionUrl": "https://raw.githubusercontent.com/theel0ja/finnish-easylist-addition/master/Finland_adb.txt",
   "tags": [
     "purpose:ads",
     "recommended",

--- a/filters/ThirdParty/filter_233_AdblockListFinland/metadata.json
+++ b/filters/ThirdParty/filter_233_AdblockListFinland/metadata.json
@@ -1,13 +1,13 @@
 {
   "filterId": 233,
-  "name": "Juvander's Adblock List for Finland",
+  "name": "Adblock List for Finland",
   "description": "Finnish adblock list",
   "timeAdded": 1404115015843,
-  "homepage": "https://www.juvander.fi/ilpo",
+  "homepage": "https://github.com/theel0ja/finnish-easylist-addition",
   "expires": "2 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "http://adb.juvander.net/Finland_adb.txt",
+  "subscriptionUrl": "https://adb.theel0ja.info/finnish-easylist-addition/Finland_adb.txt",
   "tags": [
     "purpose:ads",
     "recommended",


### PR DESCRIPTION
Juvander's list is now discontinued and removed from uBO due to its usage for political censorship.

More at uBlock Origin's issue tracker:
https://github.com/uBlockOrigin/uBlock-issues/issues/285


My announcement at bbs.io-tech.fi (a Finnish forum): https://bbs.io-tech.fi/threads/keskustelua-selainten-mainos-ja-yksityisyysestoista.692/page-10#post-3840671