### PR TITLE
Fix https://github.com/AdguardTeam/AdguardFilters/issues/25529

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -47,6 +47,8 @@ $popup,~third-party
 !***  `exclusion`
 !
 !### Easylist ###
+! https://github.com/AdguardTeam/AdguardFilters/issues/25529
+||3p.ampproject.net^$script
 ! https://github.com/AdguardTeam/AdguardFilters/issues/16453
 @@||cnbc.com^$generichide
 ! https://github.com/AdguardTeam/AdguardFilters/issues/7377


### PR DESCRIPTION
It fixes embedded Tweets on:
https://www-rosenheim24-de.cdn.ampproject.org/v/s/www.rosenheim24.de/bayern/muenchen-kurzschluesse-legen-s-bahn-muenchen-lahm-passagiere-stundenlang-eingeschlossen-10617078.amp.html?usqp=mq331AQGCAEoAVgB&amp_js_v=0.1#origin=https://www.google.de&cid=1&prerenderSize=1&visibilityState=visible&paddingTop=54&history=1&p2r=0&horizontalScrolling=0&csi=1&storage=1&viewerUrl=https://www.google.de/amp/s/www.rosenheim24.de/bayern/muenchen-kurzschluesse-legen-s-bahn-muenchen-lahm-passagiere-stundenlang-eingeschlossen-10617078.amp.html&cap=swipe,navigateTo,fragment,handshakepoll,cid,replaceUrl
and not working video on:
https://praxistipps.chip.de/microsoft-edge-werbung-blockieren-so-klappts_42804?layout=amp
and probably other issues on "AMP" websites.