### PR TITLE
list kr official filter

### DIFF
--- a/filters/ThirdParty/filter_227_List-KR/metadata.json
+++ b/filters/ThirdParty/filter_227_List-KR/metadata.json
@@ -12,6 +12,7 @@
     "purpose:ads",
     "purpose:privacy",
     "reference:2",
-    "lang:ko"
+    "lang:ko",
+    "recommended"
   ]
 }

--- a/filters/ThirdParty/filter_244_YousList/metadata.json
+++ b/filters/ThirdParty/filter_244_YousList/metadata.json
@@ -10,7 +10,6 @@
   "subscriptionUrl": "https://raw.githubusercontent.com/yous/YousList/master/youslist.txt",
   "tags": [
     "purpose:ads",
-    "lang:ko",
-    "recommended"
+    "lang:ko"
   ]
 }


### PR DESCRIPTION
originally list kr was an recommended kor ad filter but it was replaced with a yous list after list kr filter is removed for maintainers afk. but now that its back and maybe we can set list kr as an recommended kor ad filter.