### PR TITLE
Updated the Nordic (prev. Norwegian) list's metadata

### DIFF
--- a/filters/ThirdParty/filter_243_FrellwitSwedish/metadata.json
+++ b/filters/ThirdParty/filter_243_FrellwitSwedish/metadata.json
@@ -9,6 +9,7 @@
   "groupId": 7,
   "subscriptionUrl": "https://raw.githubusercontent.com/lassekongo83/Frellwits-filter-lists/master/Frellwits-Swedish-Filter.txt",
   "tags": [
+    "recommended",
     "purpose:ads",
     "purpose:annoyances",
     "purpose:privacy",

--- a/filters/ThirdParty/filter_249_NorwegianList/metadata.json
+++ b/filters/ThirdParty/filter_249_NorwegianList/metadata.json
@@ -11,6 +11,9 @@
   "tags": [
     "purpose:ads",
     "purpose:security",
-    "lang:no"
+    "lang:no",
+    "lang:da",
+    "lang:is",
+    "lang:fo"
   ]
 }

--- a/filters/ThirdParty/filter_249_NorwegianList/metadata.json
+++ b/filters/ThirdParty/filter_249_NorwegianList/metadata.json
@@ -9,12 +9,15 @@
   "groupId": 7,
   "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
   "tags": [
-    "recommended",
     "purpose:ads",
     "purpose:security",
     "lang:no",
+       "recommended",
     "lang:da",
+       "recommended",
     "lang:is",
+       "recommended",
     "lang:fo"
+       "recommended"
   ]
 }

--- a/filters/ThirdParty/filter_249_NorwegianList/metadata.json
+++ b/filters/ThirdParty/filter_249_NorwegianList/metadata.json
@@ -12,12 +12,8 @@
     "purpose:ads",
     "purpose:security",
     "lang:no",
-       "recommended",
     "lang:da",
-       "recommended",
     "lang:is",
-       "recommended",
     "lang:fo"
-       "recommended"
   ]
 }

--- a/filters/ThirdParty/filter_249_NorwegianList/metadata.json
+++ b/filters/ThirdParty/filter_249_NorwegianList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 249,
-  "name": "Dandelion Sprout's Norwegian Filters",
-  "description": " Dandelion Sprout's Norwegian Filters for tidier websites.",
+  "name": "Dandelion Sprout's Nordic Filters",
+  "description": "This list covers websites for Norway, Denmark, Iceland, Danish territories, and the Sami indigenous population. For more information, details, helpful tools, and other lists that I've made, visit https://github.com/DandelionSprout/adfilt/blob/master/Wiki/General-info.md#english.",
   "timeAdded": 1522412113779,
   "homepage": "https://github.com/DandelionSprout/adfilt",
   "expires": "2 days",
@@ -10,6 +10,7 @@
   "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
   "tags": [
     "purpose:ads",
+    "purpose:security",
     "lang:no"
   ]
 }

--- a/filters/ThirdParty/filter_249_NorwegianList/metadata.json
+++ b/filters/ThirdParty/filter_249_NorwegianList/metadata.json
@@ -9,6 +9,7 @@
   "groupId": 7,
   "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
   "tags": [
+    "recommended",
     "purpose:ads",
     "purpose:security",
     "lang:no",

--- a/locales/en/tags.json
+++ b/locales/en/tags.json
@@ -230,5 +230,9 @@
 	{
 		"tag.57.description": "Has references to the ROList filter",
 		"tag.57.name": "ROList filter reference"
+	},
+	{
+		"tag.63.description": "Designed specifically to block ads on web pages in the Faroese language",
+		"tag.63.name": "Faroese language-specific ad blocking"
 	}
 ]

--- a/tags/metadata.json
+++ b/tags/metadata.json
@@ -246,5 +246,9 @@
   {
     "tagId": 62,
     "keyword": "reference:237"
+  },
+  {
+    "tagId": 63,
+    "keyword": "lang:fo"
   }
 ]


### PR DESCRIPTION
There's been some updates in my Norwegian list, that I feel could need to be reflected in the various desktop/app/extension versions of AdGuard.

* In December 2018, after realising that Schack had most likely ceased work on his Danish adblock list, and that roughly a quarter of his list's entries had ceased to work or were for defunct domains, I decided to expand my list to also include Danish sites. While I was at it, I wrote Icelandic entries as well (initially as a self-challenge to see how much I could shrink the *Icelandic ABP List* list), and a handful of Faroese ones. Therefore the list's name is now officially **Dandelion Sprout's Nordic filters** (for tidier websites).
* * However, it does *not* cover (non-Sami) Finnish or Swedish websites, as the currently maintained lists for those languages are superior to what I could've cooked up for them.
* After I discovered that the `! Description:` tag was a thing that existed in AdGuard's desktop version, I ended up trying to use it on the Nordic list (and on ≥30 of my other and less frequently used lists as well). However, now that I see that it did not automatically apply to lists that are subscribed to from this repo, I'm adding it manually here.
* Slowly and over time, my Nordic list has also gained a secondary focus on trying to prevent mass scams and phishing sites, especially ones that so many people fell for that they got articles about them on Norwegian newssites or consumer boards. Therefore I've decided to add `purpose:security` to the metadata as well.

If you have any questions about all this, feel free to ask me about them.