### PR TITLE
Added AG_onPropertyRead/Write

### DIFF
--- a/filters/general_js_api.js
+++ b/filters/general_js_api.js
@@ -1,0 +1,229 @@
+// Aborts execution of a script when it attempts to write the specified property.
+// Based on AG_defineProperty (https://github.com/AdguardTeam/deep-override)
+//
+// Examples:
+// AG_abortOnPropertyWrite('String.fromCharCode');
+//
+// @param property property or properties chain
+// @param debug optional, if true - we will print warning when script is aborted.
+var AG_abortOnPropertyWrite = function(property, debug) {
+    var magic = Math.random().toString(36).substr(2, 8);
+    AG_defineProperty(property, {
+        beforeSet: function() {
+            if (debug) {
+                console.warn('AdGuard aborted property write: ' + property);
+            }
+            throw new ReferenceError(magic);
+        }
+    });
+
+    var baseOnError = window.onerror;
+    window.onerror = function(msg) {
+        if (typeof msg === 'string' && msg.indexOf(magic) !== -1) {
+            if (debug) {
+                console.warn('AdGuard has caught window.onerror: ' + property);
+            }
+            return true;
+        }
+        if (baseOnError instanceof Function) {
+            return baseOnError.apply(this, arguments);
+        }
+    };
+}
+
+// Aborts execution of a script when it attempts to read the specified property.
+// Based on AG_defineProperty (https://github.com/AdguardTeam/deep-override)
+//
+// Examples:
+// AG_abortOnPropertyRead('String.fromCharCode');
+//
+// @param property property or properties chain
+// @param debug optional, if true - we will print warning when script is aborted.
+var AG_abortOnPropertyRead = function(property, debug) {
+    var magic = Math.random().toString(36).substr(2, 8);
+    AG_defineProperty(property, {
+        beforeGet: function() {
+            if (debug) {
+                console.warn('AdGuard aborted property read: ' + property);
+            }
+            throw new ReferenceError(magic);
+        }
+    });
+
+    var baseOnError = window.onerror;
+    window.onerror = function(msg) {
+        if (typeof msg === 'string' && msg.indexOf(magic) !== -1) {
+            if (debug) {
+                console.warn('AdGuard has caught window.onerror: ' + property);
+            }
+            return true;
+        }
+        if (baseOnError instanceof Function) {
+            return baseOnError.apply(this, arguments);
+        }
+    };
+}
+
+// Aborts execution of an inline script when it attempts to access the specified property 
+// AND content of the <script> element matches specified regular expression.
+// Based on AG_defineProperty (https://github.com/AdguardTeam/deep-override)
+//
+// Examples:
+// AG_abortInlineScript(/zfgloadedpopup|zfgloadedpushopt/, 'String.fromCharCode');
+//
+// @param regex regular expression that the inline script contents must match
+// @param property property or properties chain
+// @param debug optional, if true - we will print warning when script is aborted.
+var AG_abortInlineScript = function(regex, property, debug) {
+    var getCurrentScript = function() {
+        if ('currentScript' in document) {
+            return document.currentScript;
+        } else {
+            var scripts = document.getElementsByTagName('script');
+            return scripts[scripts.length - 1];
+        }
+    }
+
+    var magic = Math.random().toString(36).substr(2, 8);
+    var ourScript = getCurrentScript();
+    AG_defineProperty(property, {
+        beforeGet: function() {
+            var currentScript = getCurrentScript();
+            if (currentScript instanceof HTMLScriptElement &&
+                currentScript !== ourScript &&
+                currentScript.src === '' &&
+                regex.test(currentScript.textContent)) {
+
+                if (debug) {
+                    console.warn('AdGuard aborted execution of an inline script');
+                }
+                throw new ReferenceError(magic);
+            }
+        }
+    });
+
+    var baseOnError = window.onerror;
+    window.onerror = function(msg) {
+        if (typeof msg === 'string' && msg.indexOf(magic) !== -1) {
+            if (debug) {
+                console.warn('AdGuard has caught window.onerror: ' + property);
+            }
+            return true;
+        }
+        if (baseOnError instanceof Function) {
+            return baseOnError.apply(this, arguments);
+        }
+    };
+}
+
+// Examples:
+// AG_removeCookie('/REGEX/')
+// AG_removeCookie('part of the cookie name')
+var AG_removeCookie = function(pattern) {
+    var regex = /./;
+    if (/^\/.+\/$/.test(pattern)) {
+        regex = new RegExp(pattern.slice(1, -1));
+    } else if (pattern !== '') {
+        regex = new RegExp(pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    }
+
+    var removeCookieFromHost = function(cookieName, hostName) {
+        var cookieSpec = cookieName + '=';
+        var domain1 = '; domain=' + hostName;
+        var domain2 = '; domain=.' + hostName;
+        var path = '; path=/';
+        var expiration = '; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+        document.cookie = cookieSpec + expiration;
+        document.cookie = cookieSpec + domain1 + expiration;
+        document.cookie = cookieSpec + domain2 + expiration;
+        document.cookie = cookieSpec + path + expiration;
+        document.cookie = cookieSpec + domain1 + path + expiration;
+        document.cookie = cookieSpec + domain2 + path + expiration;
+    }
+
+    var removeCookie = function() {
+        var cookies = document.cookie.split(';');
+        var iCookies = cookies.length;
+
+        while (iCookies--) {
+            cookieStr = cookies[iCookies];
+            var pos = cookieStr.indexOf('=');
+            if (pos === -1) {
+                continue;
+            }
+            var cookieName = cookieStr.slice(0, pos).trim();
+            if (!regex.test(cookieName)) {
+                continue;
+            }
+
+            var hostParts = document.location.hostname.split('.');
+            for (var i = 0; i < hostParts.length - 1; i++) {
+                var hostName = hostParts.slice(i).join('.');
+                if (hostName) {
+                    removeCookieFromHost(cookieName, hostName);
+                }
+            }
+        }
+    };
+    removeCookie();
+    window.addEventListener('beforeunload', removeCookie);
+};
+
+// Examples
+// AG_setConstant('property.chain', 'const value')
+// AG_setConstant('property.chain', 'true') // defines boolean (true), same for false;
+// AG_setConstant('property.chain', '123') // defines Number 123;
+// AG_setConstant('property.chain', 'noopFunc') // defines function(){};
+// AG_setConstant('property.chain', 'trueFunc') // defines function(){return true};
+// AG_setConstant('property.chain', 'falseFunc') // defines function(){return false};
+var AG_setConstant = function(property, value) {
+    if (value === 'undefined') {
+        value = undefined;
+    } else if (value === 'false') {
+        value = false;
+    } else if (value === 'true') {
+        value = true;
+    } else if (value === 'noopFunc') {
+        value = function() {};
+    } else if (value === 'trueFunc') {
+        value = function() {
+            return true;
+        };
+    } else if (value === 'falseFunc') {
+        value = function() {
+            return false;
+        };
+    } else if (/^\d+$/.test(value)) {
+        value = parseFloat(value);
+        if (isNaN(value)) {
+            return;
+        }
+        if (Math.abs(value) > 0x7FFF) {
+            return;
+        }
+    } else {
+        return;
+    }
+
+    var aborted = false;
+    var mustAbort = function(newValue) {
+        if (aborted) {
+            return true;
+        }
+        if (newValue !== undefined && value !== undefined && typeof newValue !== typeof value) {
+            aborted = true;
+        }
+        return aborted;
+    };
+
+    AG_defineProperty(property, {
+        get: function() {
+            return value;
+        },
+        set: function(newValue) {
+            if (mustAbort(newValue)) {
+                value = newValue;
+            }
+        }
+    });
+}

--- a/filters/general_js_api.txt
+++ b/filters/general_js_api.txt
@@ -18,14 +18,45 @@
 #%#var AG_defineProperty=function(){var p,q=Object.defineProperty;if("function"==typeof WeakMap)p=WeakMap;else{var r=0,t=function(){this.a=(r+=Math.random()).toString()};t.prototype.set=function(a,b){var d=a[this.a];d&&d[0]===a?d[1]=b:q(a,this.a,{value:[a,b],writable:!0});return this};t.prototype.get=function(a){var b;return(b=a[this.a])&&b[0]===a?b[1]:void 0};t.prototype.has=function(a){var b=a[this.a];return b?b[0]===a:!1};p=t}function u(a){this.b=a;this.h=Object.create(null)}function v(a,b,d,e){this.a=a;this.i=b;this.c=d;this.f=e}function w(){this.g=/^([^\\\.]|\\.)*?\./;this.j=/\\(.)/g;this.a=new p}function x(a,b){var d=b.f;if(d&&!("beforeGet"in d||"beforeSet"in d))return z(d);var e={get:function(){var c=b.f;c&&c.beforeGet&&c.beforeGet.call(this,b.a.b);a:if(c=b.g)c=A(c)?c.value:c.get?c.get.call(this):void 0;else{c=b.a.b;if(b.i in c&&(c=B(c),null!==c)){var d=C.call(c,b.i);c=d?d.call(this):c[b.i];break a}c=void 0}(this===b.a.b||D.call(b.a.b,this))&&E(a,c,b.c);return c},set:function(c){if(this===b.a.b||D.call(b.a.b,this)){b.f&&b.f.beforeSet&&(c=b.f.beforeSet.call(this,c,this));var d=b.g;d&&A(d)&&d.value===c?c=!0:(d=F(b,c,this),G(c)&&(c=H(a,c),I(a,c,b.c)),c=d)}else c=F(b,c,this);return c}};d&&J(d,e,K);return e}function I(a,b,d){for(var e in d.h){var c=d.h[e];if(b.h[e]){var h=a,g=b.h[e],k=c;!k.f||g.f||"undefined"===typeof g.a.b||g.g||(g.g=z(k.f));g.c&&k.c&&g.c!==k.c&&I(h,g.c,k.c)}else{g=h=void 0;k=a;var f=b,l=c.i,m="undefined"!==typeof f.b,y=!1;m&&(g=L(f.b,l))&&!g.configurable&&(y=!0,h=f.b[l]);var n=y?H(k,h):new u(c.c.b);I(k,n,c.c);n=new v(f,l,n,c.f);f.h[l]=n;m&&(n.g=g,m=x(k,n),y?E(k,h,c.c):(q(f.b,l,m),g&&A(g)&&(M(m,g.value,f.b),E(k,g.value,c.c))))}}}function E(a,b,d){G(b)&&(b=H(a,b),I(a,b,d))}function F(a,b,d){var e=a.g;if(!e){e=B(a.a.b);if(null!==e&&(e=N.call(e,a.i)))return e.call(d,b);if(!O(a.a.b))return!1;a.g={value:b,configurable:!0,writable:!0,enumerable:!0};return!0}return M(e,b,d)}function H(a,b){var d=a.a.get(b);d||(d=new u(b),a.a.set(b,d));return d}function A(a){return"undefined"!==typeof a.writable}function J(a,b,d){for(var e=0,c=d.length;e<c;e++){var h=d[e];h in a&&(b[h]=a[h])}}function z(a){if(a){var b={};J(a,b,P);return b}}function M(a,b,d){if(A(a))return a.writable?(a.value=b,!0):!1;if(!a.set)return!1;a.set.call(d,b);return!0}var P="configurable enumerable value get set writable".split(" "),K=P.slice(0,2),L=Object.getOwnPropertyDescriptor,O=Object.isExtensible,B=Object.getPrototypeOf,D=Object.prototype.isPrototypeOf,C=Object.prototype.__lookupGetter__||function(a){return(a=Q(this,a))&&a.get?a.get:void 0},N=Object.prototype.__lookupSetter__||function(a){return(a=Q(this,a))&&a.set?a.set:void 0};function Q(a,b){if(b in a){for(;!w.hasOwnProperty.call(a,b);)a=B(a);return L(a,b)}}function G(a){var b=typeof a;return"function"===b||"object"===b&&null!==a?!0:!1}var R;return function(a,b,d){R||(R=new w);var e=R;d=d||window;var c=new u;a+=".";var h=c||new u;for(var g=e.g,k=e.j,f,l,m;a;){f=g.exec(a);if(null===f)throw 1;f=f[0].length;l=a.slice(0,f-1).replace(k,"$1");a=a.slice(f);(f=h.h[l])?m=f.c:(m=new u,f=new v(h,l,m),h.h[l]=f);h=m}if(!f)throw 1;a=f;a.f=b;E(e,d,c)};}();
 
 !
-! AG_abortInlineScript(functionRegex, 'property.chain')
-! Aborts execution of a function that matches "functionRegex" when accessing a property defined by "property.chain"
-! Based on AG_defineProperty
+! AG_abortOnPropertyWrite(property, debug)
+! Aborts execution of a script when it attempts to write the specified property.
+! Based on AG_defineProperty (https://github.com/AdguardTeam/deep-override)
+!
+! Examples:
+! AG_abortOnPropertyWrite('String.fromCharCode');
+!
+! @param property property or properties chain
+! @param debug optional, if true - we will print warning when script is aborted.
+!
+#%#var AG_abortOnPropertyWrite=function(a,b){var c=Math.random().toString(36).substr(2,8);AG_defineProperty(a,{beforeSet:function(){b&&console.warn("AdGuard aborted property write: "+a);throw new ReferenceError(c);}});var d=window.onerror;window.onerror=function(e){if("string"===typeof e&&-1!==e.indexOf(c))return b&&console.warn("AdGuard has caught window.onerror: "+a),!0;if(d instanceof Function)return d.apply(this,arguments)}};
+
+!
+! AG_abortOnPropertyRead(property, debug)
+! Aborts execution of a script when it attempts to read the specified property.
+! Based on AG_defineProperty (https://github.com/AdguardTeam/deep-override)
+!
+! Examples:
+! AG_abortOnPropertyRead('String.fromCharCode');
+!
+! @param property property or properties chain
+! @param debug optional, if true - we will print warning when script is aborted.
+!
+#%#var AG_abortOnPropertyRead=function(a,b){var c=Math.random().toString(36).substr(2,8);AG_defineProperty(a,{beforeGet:function(){b&&console.warn("AdGuard aborted property read: "+a);throw new ReferenceError(c);}});var d=window.onerror;window.onerror=function(e){if("string"===typeof e&&-1!==e.indexOf(c))return b&&console.warn("AdGuard has caught window.onerror: "+a),!0;if(d instanceof Function)return d.apply(this,arguments)}};
+
+!
+! AG_abortInlineScript(regex, property, debug)
+! Aborts execution of an inline script when it attempts to access the specified property 
+! AND content of the <script> element matches specified regular expression.
+! Based on AG_defineProperty (https://github.com/AdguardTeam/deep-override)
 !
 ! Examples:
 ! AG_abortInlineScript(/zfgloadedpopup|zfgloadedpushopt/, 'String.fromCharCode');
 !
-#%#var AG_abortInlineScript=function(d,e,f){var c;if("currentScript"in document)var b=function(){return document.currentScript};else b=function(){var a=document.getElementsByTagName("script");return a[a.length-1]},window.addEventListener("DOMContentLoaded",function(){b=function(){return null}});AG_defineProperty(e,{beforeGet:function(){var a=b();if(a&&a!==c&&(c=a,""===a.src&&d.test(a.textContent)))throw setTimeout(function(){console.warn("AdGuard aborted an execution of an inline script")}),null;}},f)};
+! @param regex regular expression that the inline script contents must match
+! @param property property or properties chain
+! @param debug optional, if true - we will print warning when script is aborted.
+!
+#%#var AG_abortInlineScript=function(g,b,c){var d=function(){if("currentScript"in document)return document.currentScript;var a=document.getElementsByTagName("script");return a[a.length-1]},e=Math.random().toString(36).substr(2,8),h=d();AG_defineProperty(b,{beforeGet:function(){var a=d();if(a instanceof HTMLScriptElement&&a!==h&&""===a.src&&g.test(a.textContent))throw c&&console.warn("AdGuard aborted execution of an inline script"),new ReferenceError(e);}});var f=window.onerror;window.onerror=function(a){if("string"===typeof a&&-1!==a.indexOf(e))return c&&console.warn("AdGuard has caught window.onerror: "+b),!0;if(f instanceof Function)return f.apply(this,arguments)}};
 
 ! 
 ! AG_setConstant('property.chain', 'true') // defines boolean (true), same for false;
@@ -33,5 +64,6 @@
 ! AG_setConstant('property.chain', 'noopFunc') // defines function(){};
 ! AG_setConstant('property.chain', 'trueFunc') // defines function(){return true};
 ! AG_setConstant('property.chain', 'falseFunc') // defines function(){return false};
+!
 #%#var AG_setConstant=function(e,a){if("undefined"===a)a=void 0;else if("false"===a)a=!1;else if("true"===a)a=!0;else if("noopFunc"===a)a=function(){};else if("trueFunc"===a)a=function(){return!0};else if("falseFunc"===a)a=function(){return!1};else if(/^\d+$/.test(a)){if(a=parseFloat(a),isNaN(a)||32767<Math.abs(a))return}else return;var b=!1;AG_defineProperty(e,{get:function(){return a},set:function(c){if(b)var d=!0;else void 0!==c&&void 0!==a&&typeof c!==typeof a&&(b=!0),d=b;d&&(a=c)}})};
 ! JS API FINISH


### PR DESCRIPTION
1. Added `general_js_api.js` file with the non-minified functions implementations.
2. Changed `AG_abortInlineScript` implementation -- added `debug` parameter. If it is specified, the script will print a line to the browser console when the work is done.  
3. Added `AG_abortOnPropertyWrite` and `AG_abortOnPropertyRead` functions.
4. **`debug`** is not supposed to be used in the filter lists. It is useful for debugging purposes though.