### PR TITLE
fix #32056 poczta.wp.pl

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -185,6 +185,10 @@ _campaign=$popup
 ||acs.$domain=~youku.com|~tudou.com
 !###############
 !
+!### Official Polish filters for AdBlock, uBlock Origin & AdGuard ###
+~poczta.wp.pl,wp.pl##body > div:nth-of-type(1)[style^="display: block;"]
+!###########################
+!
 !### NoCoin Filter List ###
 ||github.io^$third-party,xmlhttprequest,domain=~facebook.com|~gametactic.org|~github.com|~github.io|~tumblr.com|~wottactic.com
 !###########################


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/32056

Rule is applied to poczta.wp.pl as it is applied to wp.pl (~poczta.wp.pl gets ignored)