### PR TITLE
pcgames.de mobile - fixing click on main page

### DIFF
--- a/filters/ThirdParty/filter_244_YousList/template.txt
+++ b/filters/ThirdParty/filter_244_YousList/template.txt
@@ -1,2 +1,4 @@
 !
 @include "https://raw.githubusercontent.com/yous/YousList/master/youslist.txt" /exclude="exclusions.txt"
+! pcgames.de mobile - fixing click on main page
+@@||script.ioam.de/iam.js$domain=pcgames.de


### PR DESCRIPTION
pcgames.de mobile - fixing click on main page
Without rule the click on a link is not doing anything on main page.