### PR TITLE
pcgames.de mobile - fixing click on main page

### DIFF
--- a/filters/ThirdParty/filter_215_FanboysEnancedTrackingList/template.txt
+++ b/filters/ThirdParty/filter_215_FanboysEnancedTrackingList/template.txt
@@ -1,2 +1,4 @@
 !
 @include "https://secure.fanboy.co.nz/enhancedstats.txt" /exclude="../../exclusions.txt"
+! pcgames.de mobile - fixing click on main page
+@@||script.ioam.de/iam.js$domain=pcgames.de


### PR DESCRIPTION
pcgames.de mobile - fixing click on main page
Without rule the click on a link is not doing anything on main page.