### PR TITLE
enable back void.gr

### DIFF
--- a/filters/ThirdParty/filter_121_VoidGr/metadata.json
+++ b/filters/ThirdParty/filter_121_VoidGr/metadata.json
@@ -12,6 +12,5 @@
     "purpose:ads",
     "reference:101",
     "lang:el"
-  ],
-  "disabled": true
+  ]
 }


### PR DESCRIPTION
I've temporarily disabled this filter because it was messing up the build (for some reason, `https://www.void.gr/kargig/void-gr-filters.txt` couldn't be downloaded on the build server).

We should try enabling it back in a couple of days.

I created this PR to test the build on Travis, and so that we don't forget to enable it back.