### PR TITLE
Fix/windowscentral images

### DIFF
--- a/filters/ThirdParty/filter_121_VoidGr/metadata.json
+++ b/filters/ThirdParty/filter_121_VoidGr/metadata.json
@@ -12,6 +12,5 @@
     "purpose:ads",
     "reference:101",
     "lang:el"
-  ],
-  "disabled": true
+  ]
 }

--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -48,6 +48,8 @@ $popup,~third-party
 !***  `exclusion`
 !
 !### Easylist ###
+! Fixing images on androidcentral.com and windowscentral.com
+androidcentral.com,windowscentral.com##a[href^="/e?link="]
 ! Excluding /adframe. as it is used often by adblock detectors
 /adframe.
 ! https://github.com/AdguardTeam/AdguardFilters/issues/31239


### PR DESCRIPTION
Guys, this is a quick fix for no images in articles.
See the example here:
https://www.windowscentral.com/best-laptop-touchpad

Plz report this to easylist and merge afterwards.