### PR TITLE
Changed the link to my list

### DIFF
--- a/filters/ThirdParty/filter_249_NorwegianList/metadata.json
+++ b/filters/ThirdParty/filter_249_NorwegianList/metadata.json
@@ -7,7 +7,7 @@
   "expires": "2 days",
   "displayNumber": 249,
   "groupId": 7,
-  "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
+  "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/NordicFiltersAdGuard.txt",
   "tags": [
     "recommended",
     "purpose:ads",


### PR DESCRIPTION
Thanks in large part to critical start-pushing by @ameshkov, I have now become able to create an AdGuard-tailorsewn version of my Nordic list, the most important difference being that anti-scam entries are now optimalised for AdGuard's syntax.