### PR TITLE
Re-enabled ChinaList+EasyList

### DIFF
--- a/filters/ThirdParty/filter_219_ChinaListAndEasyList/metadata.json
+++ b/filters/ThirdParty/filter_219_ChinaListAndEasyList/metadata.json
@@ -12,6 +12,5 @@
     "purpose:ads",
     "reference:101",
     "lang:zh"
-  ],
-  "disabled": true
+  ]
 }


### PR DESCRIPTION
It seems that http://sub.adtchrome.com/adt-chinalist-easylist.txt loads correctly now, so I think that we can re-enable `ChinaList+EasyList`, or not yet?