### PR TITLE
Excluded `/generate_204$image,other,script` rule from EasyPrivacy

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -113,6 +113,11 @@ biggestplayer.me##.adblock1
 ! End: Easylist
 !################
 !
+!### EasyPrivacy ###
+/generate_204$
+! End: EasyPrivacy
+!###################
+!
 !### Liste AR ###
 ! https://github.com/AdguardTeam/AdguardFilters/issues/35459
 $popup,domain=aflamsexnek.com|


### PR DESCRIPTION
Not a tracker. Causes some issues.