### PR TITLE
fix finanznachrichten.de

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -55,6 +55,8 @@ $popup,~third-party
 ! Excluding /google_ad_ because it gives a false positive on https://www.theregister.co.uk/2019/09/19/google_ad_blockers/
 ! and it is not really useful according to stats
 /google_ad_
+! https://github.com/AdguardTeam/AdguardFilters/issues/42485
+||feadrope.net^$document
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/116
 ||gvt1.com^$third-party
 ! https://github.com/AdguardTeam/AdguardFilters/issues/31239


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/42485

$document block rule has higher priority than $important exclusion rule. Site only serves AdFender picture file.