### PR TITLE
Disable Web Annoyances Ultralist temporary

### DIFF
--- a/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
+++ b/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
@@ -10,5 +10,6 @@
   "subscriptionUrl": "https://raw.githubusercontent.com/yourduskquibbles/webannoyances/master/ultralist.txt",
   "tags": [
     "purpose:annoyances"
-  ]
+  ],
+  "disabled": true
 }


### PR DESCRIPTION
Due to issue with `!#include` directive probably.