### PR TITLE
Change description for ROLIST2 and other fixes

### DIFF
--- a/filters/ThirdParty/filter_101_EasyList/metadata.json
+++ b/filters/ThirdParty/filter_101_EasyList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 101,
   "name": "EasyList",
-  "description": "EasyList is the primary subscription that removes adverts from web pages in English language.",
+  "description": "EasyList is the primary subscription that removes adverts from web pages in English language. Already included in AdGuard Base filter.",
   "timeAdded": 1404115015843,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_102_ABPindo/metadata.json
+++ b/filters/ThirdParty/filter_102_ABPindo/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 102,
   "name": "ABPindo",
-  "description": "Bahasa Indonesia supplement for EasyList.",
+  "description": "Bahasa Indonesia supplement for EasyList",
   "timeAdded": 1404115015843,
   "homepage": "http://abpindo.blogspot.com/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_102_ABPindo/metadata.json
+++ b/filters/ThirdParty/filter_102_ABPindo/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 102,
   "name": "ABPindo",
-  "description": "Bahasa Indonesia supplement for EasyList",
+  "description": "Bahasa Indonesia supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "http://abpindo.blogspot.com/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_103_BulgarianList/metadata.json
+++ b/filters/ThirdParty/filter_103_BulgarianList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 103,
   "name": "Bulgarian list",
-  "description": "български supplement for EasyList.",
+  "description": "Български supplement for EasyList",
   "timeAdded": 1404115015843,
   "homepage": "http://stanev.org/abp/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_103_BulgarianList/metadata.json
+++ b/filters/ThirdParty/filter_103_BulgarianList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 103,
   "name": "Bulgarian list",
-  "description": "Български supplement for EasyList",
+  "description": "Български supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "http://stanev.org/abp/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_104_EasyListChina/metadata.json
+++ b/filters/ThirdParty/filter_104_EasyListChina/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 104,
   "name": "EasyList China",
-  "description": "中文 supplement for EasyList",
+  "description": "中文 supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "http://abpchina.org/forum/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_105_EasyListCzechAndSlovak/metadata.json
+++ b/filters/ThirdParty/filter_105_EasyListCzechAndSlovak/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 105,
   "name": "EasyList Czech and Slovak",
-  "description": "Čeština, slovenčina supplement for EasyList",
+  "description": "Čeština, slovenčina supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/tomasko126/easylistczechandslovak",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_105_EasyListCzechAndSlovak/metadata.json
+++ b/filters/ThirdParty/filter_105_EasyListCzechAndSlovak/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 105,
   "name": "EasyList Czech and Slovak",
-  "description": "čeština, slovenčina supplement for EasyList",
+  "description": "Čeština, slovenčina supplement for EasyList",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/tomasko126/easylistczechandslovak",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_106_EasyListDutch/metadata.json
+++ b/filters/ThirdParty/filter_106_EasyListDutch/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 106,
   "name": "EasyList Dutch",
-  "description": "Nederlands supplement for EasyList",
+  "description": "Nederlands supplement for EasyList. Already included in AdGuard Dutch filter.",
   "timeAdded": 1404115015843,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_107_EasyListGermany/metadata.json
+++ b/filters/ThirdParty/filter_107_EasyListGermany/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 107,
   "name": "EasyList Germany",
-  "description": "Deutsch supplement for EasyList",
+  "description": "Deutsch supplement for EasyList. Already included in AdGuard German filter.",
   "timeAdded": 1404115015843,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_109_EasyListItaly/metadata.json
+++ b/filters/ThirdParty/filter_109_EasyListItaly/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 109,
   "name": "EasyList Italy",
-  "description": "italiano supplement for EasyList",
+  "description": "Italiano supplement for EasyList",
   "timeAdded": 1404115015843,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_109_EasyListItaly/metadata.json
+++ b/filters/ThirdParty/filter_109_EasyListItaly/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 109,
   "name": "EasyList Italy",
-  "description": "Italiano supplement for EasyList",
+  "description": "Italiano supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_110_EasyListLithuania/metadata.json
+++ b/filters/ThirdParty/filter_110_EasyListLithuania/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 110,
   "name": "EasyList Lithuania",
-  "description": "lietuvių kalba supplement for EasyList",
+  "description": "Lietuvių kalba supplement for EasyList",
   "timeAdded": 1404115015843,
   "homepage": "http://margevicius.lt/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_110_EasyListLithuania/metadata.json
+++ b/filters/ThirdParty/filter_110_EasyListLithuania/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 110,
   "name": "EasyList Lithuania",
-  "description": "Lietuvių kalba supplement for EasyList",
+  "description": "Lietuvių kalba supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "http://margevicius.lt/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_111_LatvianList/metadata.json
+++ b/filters/ThirdParty/filter_111_LatvianList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 111,
   "name": "Latvian List",
-  "description": "latviešu valoda supplement for EasyList",
+  "description": "Latviešu valoda supplement for EasyList",
   "timeAdded": 1404115015843,
   "homepage": "https://notabug.org/latvian-list/adblock-latvian",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_111_LatvianList/metadata.json
+++ b/filters/ThirdParty/filter_111_LatvianList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 111,
   "name": "Latvian List",
-  "description": "Latviešu valoda supplement for EasyList",
+  "description": "Latviešu valoda supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "https://notabug.org/latvian-list/adblock-latvian",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_113_ListeFR/metadata.json
+++ b/filters/ThirdParty/filter_113_ListeFR/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 113,
   "name": "Liste FR",
-  "description": "français supplement for EasyList",
+  "description": "Français supplement for EasyList. Already included in AdGuard French filter.",
   "timeAdded": 1404115015843,
   "homepage": "http://adblock-listefr.com/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_114_ROList/metadata.json
+++ b/filters/ThirdParty/filter_114_ROList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 114,
   "name": "ROList",
-  "description": "Românesc supplement for EasyList",
+  "description": "Românesc supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "http://www.zoso.ro/rolist",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_114_ROList/metadata.json
+++ b/filters/ThirdParty/filter_114_ROList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 114,
   "name": "ROList",
-  "description": "românesc supplement for EasyList",
+  "description": "Românesc supplement for EasyList",
   "timeAdded": 1404115015843,
   "homepage": "http://www.zoso.ro/rolist",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_117_PolishSubFilters/metadata.json
+++ b/filters/ThirdParty/filter_117_PolishSubFilters/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 117,
   "name": "Polskie Filtry Wewnętrzne",
-  "description": "Polskie Filtry Wewnętrzne",
+  "description": "Polskie Filtry Wewnętrzne.",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/KonoromiHimaries/PolishSubFilters",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_118_EasyPrivacy/metadata.json
+++ b/filters/ThirdParty/filter_118_EasyPrivacy/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 118,
   "name": "EasyPrivacy",
-  "description": "Privacy protection supplement for EasyList",
+  "description": "Privacy protection supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_118_EasyPrivacy/metadata.json
+++ b/filters/ThirdParty/filter_118_EasyPrivacy/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 118,
   "name": "EasyPrivacy",
-  "description": "Privacy protection supplement for EasyList.",
+  "description": "Privacy protection supplement for EasyList",
   "timeAdded": 1404115015843,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_119_IcelandicABPList/metadata.json
+++ b/filters/ThirdParty/filter_119_IcelandicABPList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 119,
   "name": "Icelandic ABP List",
-  "description": "íslenska supplement for EasyList",
+  "description": "Íslenska supplement for EasyList",
   "timeAdded": 1404115015843,
   "homepage": "http://adblock.gardar.net/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_119_IcelandicABPList/metadata.json
+++ b/filters/ThirdParty/filter_119_IcelandicABPList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 119,
   "name": "Icelandic ABP List",
-  "description": "Íslenska supplement for EasyList",
+  "description": "Íslenska supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "http://adblock.gardar.net/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_121_VoidGr/metadata.json
+++ b/filters/ThirdParty/filter_121_VoidGr/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 121,
   "name": "Greek AdBlock Filter",
-  "description": "Ελληνικά supplement for EasyList",
+  "description": "Ελληνικά supplement for EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/kargig/greek-adblockplus-filter",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_121_VoidGr/metadata.json
+++ b/filters/ThirdParty/filter_121_VoidGr/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 121,
   "name": "Greek AdBlock Filter",
-  "description": "ελληνικά supplement for EasyList",
+  "description": "Ελληνικά supplement for EasyList",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/kargig/greek-adblockplus-filter",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_122_FanboysAnnoyances/metadata.json
+++ b/filters/ThirdParty/filter_122_FanboysAnnoyances/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 122,
   "name": "Fanboy's Annoyances",
-  "description": "Removes in-page pop-ups and other annoyances. (Includes Fanboy's Social Blocking & Cookiemonster Lists.)",
+  "description": "Removes in-page pop-ups and other annoyances. Includes Fanboy's Social Blocking & Cookiemonster Lists.",
   "timeAdded": 1404115015843,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_123_FanboysSocialBlockingList/metadata.json
+++ b/filters/ThirdParty/filter_123_FanboysSocialBlockingList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 123,
   "name": "Fanboy's Social Blocking List",
-  "description": "Hide and block social content, social widgets, social scripts and social icons. (Already included in Fanboy's Annoyances list.)",
+  "description": "Hide and block social content, social widgets, social scripts and social icons. Already included in Fanboy's Annoyances list.",
   "timeAdded": 1404115015843,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
+++ b/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 201,
   "name": "Web Annoyances Ultralist",
-  "description": "Block annoying web elements and reclaim lost screen real estate.",
+  "description": "Blocks annoying web elements and reclaims lost screen real estate.",
   "timeAdded": 1560248829763,
   "homepage": "https://github.com/yourduskquibbles/webannoyances/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_202_FiltrosNauscopicos/metadata.json
+++ b/filters/ThirdParty/filter_202_FiltrosNauscopicos/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 202,
   "name": "(Obsolete) Filtros Nauscopicos",
-  "description": "español",
+  "description": "Español adblock filter list.",
   "timeAdded": 1404115015843,
   "homepage": "http://nauscopio.nireblog.com/cat/filtrado",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_202_FiltrosNauscopicos/metadata.json
+++ b/filters/ThirdParty/filter_202_FiltrosNauscopicos/metadata.json
@@ -1,15 +1,17 @@
 {
   "filterId": 202,
-  "name": "Filtros Nauscopicos",
+  "name": "(Obsolete) Filtros Nauscopicos",
   "description": "español",
   "timeAdded": 1404115015843,
   "homepage": "http://nauscopio.nireblog.com/cat/filtrado",
   "expires": "2 days",
-  "displayNumber": 2,
+  "displayNumber": 100,
   "groupId": 7,
   "subscriptionUrl": "http://abp.mozilla-hispano.org/nauscopio/filtros.txt",
   "tags": [
+    "obsolete",
     "purpose:ads",
     "lang:es"
-  ]
+  ],
+  "disabled": true
 }

--- a/filters/ThirdParty/filter_203_hufilter/metadata.json
+++ b/filters/ThirdParty/filter_203_hufilter/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 203,
   "name": "hufilter",
-  "description": "Magyar adblock filter list",
+  "description": "Magyar adblock filter list.",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/hufilter/hufilter/wiki",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_203_hufilter/metadata.json
+++ b/filters/ThirdParty/filter_203_hufilter/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 203,
   "name": "hufilter",
-  "description": "magyar",
+  "description": "Magyar adblock filter list",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/hufilter/hufilter/wiki",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_206_Xfiles/metadata.json
+++ b/filters/ThirdParty/filter_206_Xfiles/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 206,
   "name": "Xfiles",
-  "description": "Italiano adblock filter list",
+  "description": "Italiano adblock filter list.",
   "timeAdded": 1404115015843,
   "homepage": "https://xfiles.noads.it/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_206_Xfiles/metadata.json
+++ b/filters/ThirdParty/filter_206_Xfiles/metadata.json
@@ -1,13 +1,13 @@
 {
   "filterId": 206,
   "name": "Xfiles",
-  "description": "italiano",
+  "description": "Italiano adblock filter list",
   "timeAdded": 1404115015843,
-  "homepage": "http://noads.it/",
+  "homepage": "https://xfiles.noads.it/",
   "expires": "2 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "https://dl.dropboxusercontent.com/u/1289327/abpxfiles/filtri.txt",
+  "subscriptionUrl": "https://raw.githubusercontent.com/gioxx/xfiles/master/filtri.txt",
   "tags": [
     "purpose:ads",
     "lang:it"

--- a/filters/ThirdParty/filter_207_AdblockWarningRemovalList/metadata.json
+++ b/filters/ThirdParty/filter_207_AdblockWarningRemovalList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 207,
   "name": "Adblock Warning Removal List",
-  "description": "removes anti-adblock warnings and other obtrusive messages",
+  "description": "Removes anti-adblock warnings and other obtrusive messages.",
   "timeAdded": 1404115015843,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_214_ABPVNList/metadata.json
+++ b/filters/ThirdParty/filter_214_ABPVNList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 214,
   "name": "ABPVN List",
-  "description": "vietnamese",
+  "description": "Vietnamese adblock filter list.",
   "timeAdded": 1404115015843,
   "homepage": "http://abpvn.com/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_217_PolskiFiltrCookies/metadata.json
+++ b/filters/ThirdParty/filter_217_PolskiFiltrCookies/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 217,
   "name": "Polskie Filtry Ciasteczkowe",
-  "description": "Polski filtr cookies",
+  "description": "Polski filtr cookies.",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/MajkiIT/polish-ads-filter#polish-filters-for-adblock-ublock-origin--adguard",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_217_PolskiFiltrCookies/metadata.json
+++ b/filters/ThirdParty/filter_217_PolskiFiltrCookies/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 217,
   "name": "Polskie Filtry Ciasteczkowe",
-  "description": "polski filtr cookies",
+  "description": "Polski filtr cookies",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/MajkiIT/polish-ads-filter#polish-filters-for-adblock-ublock-origin--adguard",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_221_PolskiFiltrSocial/metadata.json
+++ b/filters/ThirdParty/filter_221_PolskiFiltrSocial/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 221,
   "name": "Polskie Filtry Społecznościowe",
-  "description": "Polski social filtr",
+  "description": "Polski social filtr.",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/MajkiIT/polish-ads-filter#polish-filters-for-adblock-ublock-origin--adguard",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_224_KoreanAdblockList/metadata.json
+++ b/filters/ThirdParty/filter_224_KoreanAdblockList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 224,
   "name": "(Obsolete) Korean Adblock List",
-  "description": "Korean Adblock List",
+  "description": "Korean Adblock List.",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/gfmaster/adblock-korea-contrib",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_224_KoreanAdblockList/metadata.json
+++ b/filters/ThirdParty/filter_224_KoreanAdblockList/metadata.json
@@ -1,15 +1,17 @@
 {
   "filterId": 224,
-  "name": "Korean Adblock List",
+  "name": "(Obsolete) Korean Adblock List",
   "description": "Korean Adblock List",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/gfmaster/adblock-korea-contrib",
   "expires": "2 days",
-  "displayNumber": 2,
+  "displayNumber": 100,
   "groupId": 7,
   "subscriptionUrl": "https://raw.githubusercontent.com/gfmaster/adblock-korea-contrib/master/filter.txt",
   "tags": [
+    "obsolete",
     "purpose:ads",
     "lang:ko"
-  ]
+  ],
+  "disabled": true
 }

--- a/filters/ThirdParty/filter_227_List-KR/metadata.json
+++ b/filters/ThirdParty/filter_227_List-KR/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 227,
   "name": "List-KR",
-  "description": "Filter that enables removing of ads, trackers, and various scripts from websites with Korean content. Based on Corset, Korean Adblock filter, Youslist. Combined and augmented with AdGuard-specific rules for enhanced filtering This filter is expected to be used alongside with English filter.",
+  "description": "Filter that enables removing of ads, trackers, and various scripts from websites with Korean content. Based on Corset, Korean Adblock filter, Youslist. Combined and augmented with AdGuard-specific rules for enhanced filtering. This filter is expected to be used alongside with Base filter.",
   "timeAdded": 1404115015843,
   "homepage": "https://list-kr.github.io/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_228_xinggsf/metadata.json
+++ b/filters/ThirdParty/filter_228_xinggsf/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 228,
   "name": "xinggsf",
-  "description": "One more China filter list",
+  "description": "One more China filter list.",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/xinggsf/Adblock-Plus-Rule",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_228_xinggsf/metadata.json
+++ b/filters/ThirdParty/filter_228_xinggsf/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 228,
   "name": "xinggsf",
-  "description": "One more China filter by",
+  "description": "One more China filter list",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/xinggsf/Adblock-Plus-Rule",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_234_ROList2/metadata.json
+++ b/filters/ThirdParty/filter_234_ROList2/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 234,
   "name": "ROLIST2",
-  "description": "This is a complementary list for RoList with annoyances that are not necessarily banners",
+  "description": "This is a complementary list for RoList with annoyances that are not necessarily banners. It is a very agressive list and not recommended for beginners.",
   "timeAdded": 1404115015843,
   "homepage": "https://zoso.ro/rolist/",
   "expires": "2 days",
@@ -9,6 +9,7 @@
   "groupId": 7,
   "subscriptionUrl": "https://www.zoso.ro/pages/rolist2.txt",
   "tags": [
+    "problematic",
     "purpose:annoyances",
     "lang:ro",
     "reference:114"

--- a/filters/ThirdParty/filter_235_adblock-iran/metadata.json
+++ b/filters/ThirdParty/filter_235_adblock-iran/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 235,
   "name": "Iranian filter",
-  "description": "Adblock Iran filter",
+  "description": "Ad blocking rules for iranian/persian websites.",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/farrokhi/adblock-iran",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_235_adblock-iran/metadata.json
+++ b/filters/ThirdParty/filter_235_adblock-iran/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 235,
   "name": "Iranian filter",
-  "description": "Ad blocking rules for iranian/persian websites.",
+  "description": "Ad blocking rules for Iranian/Persian websites.",
   "timeAdded": 1404115015843,
   "homepage": "https://github.com/farrokhi/adblock-iran",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_237_PolishAnnoyance/metadata.json
+++ b/filters/ThirdParty/filter_237_PolishAnnoyance/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 237,
   "name": "Polskie Filtry Elementów Irytujących",
-  "description": "Filters that hide and block pop-ups, widgets, newsletters, push notifications, arrows and other irritating elements (include Polish Cookies Filters)",
+  "description": "Filtry ukrywające i blokujące wyskakujące okienka, widgety, newslettery, powiadomienia push, strzałki, otagowane linki wewnętrzne, które są nie na temat artykułów i inne drażniące elementy. Polskie Filtry Ciasteczkowe są już w nich zawarte.",
   "timeAdded": 1518635735865,
   "homepage": "https://polishannoyancefilters.netlify.com",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_239_FanboyAntifonts/metadata.json
+++ b/filters/ThirdParty/filter_239_FanboyAntifonts/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 239,
   "name": "Fanboy's Anti-thirdparty Fonts",
-  "description": "A filter to block third-party fonts. (May break the look and design of some websites)",
+  "description": "A filter to block third-party fonts. It may break the look and design of some websites.",
   "timeAdded": 1404115015843,
   "homepage": "http://www.fanboy.co.nz/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_241_FanboyCookiemonster/metadata.json
+++ b/filters/ThirdParty/filter_241_FanboyCookiemonster/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 241,
   "name": "Fanboy's Cookiemonster List",
-  "description": "This will remove cookie and privacy warnings. (Already included in Fanboy's Annoyances list.)",
+  "description": "Removes cookie and privacy warnings. Already included in Fanboy's Annoyances list.",
   "timeAdded": 1404115015843,
   "homepage": "http://www.fanboy.co.nz/",
   "expires": "2 days",

--- a/filters/ThirdParty/filter_246_EasyListPolish/metadata.json
+++ b/filters/ThirdParty/filter_246_EasyListPolish/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 246,
   "name": "EasyList Polish",
-  "description": "Polish supplement for EasyList",
+  "description": "Polish supplement for EasyList.",
   "timeAdded": 1522053342138,
   "homepage": "https://easylist.to/",
   "expires": "2 days",

--- a/filters/filter_12_Safari/metadata.json
+++ b/filters/filter_12_Safari/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 12,
   "name": "AdGuard Safari filter",
-  "description": "Special filter for Safari 9+ on iOS and Mac OS. We need a separate filter for Safari browser because it does not fully support our rules syntax.",
+  "description": "Special filter for Safari 9+ on iOS and Mac OS. We need a separate filter for Safari browser because it does not fully support our rules syntax. Already included in AdGuard Base filter.",
   "timeAdded": 1404115015843,
   "homepage": "https://kb.adguard.com/en/general/adguard-ad-filters#safari-filter",
   "expires": "2 days",

--- a/filters/filter_4_Social/metadata.json
+++ b/filters/filter_4_Social/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 4,
   "name": "AdGuard Social Media filter",
-  "description": "Filter for social media widgets (Like buttons and such)",
+  "description": "Filter for social media widgets such as “Like” and “Share” buttons and more.",
   "timeAdded": 1404115015843,
   "homepage": "https://kb.adguard.com/en/general/adguard-ad-filters#social-media-filter",
   "expires": "2 days",

--- a/filters/filter_4_Social/metadata.json
+++ b/filters/filter_4_Social/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 4,
   "name": "AdGuard Social Media filter",
-  "description": "Filter for social media widgets such as “Like” and “Share” buttons and more.",
+  "description": "Filter for social media widgets such as 'Like' and 'Share' buttons and more.",
   "timeAdded": 1404115015843,
   "homepage": "https://kb.adguard.com/en/general/adguard-ad-filters#social-media-filter",
   "expires": "2 days",


### PR DESCRIPTION
- change description for ROLIST2
- mark `Filtros Nauscopicos` and `Korean Adblock List` as obsolete
- update subscriptionUrl  for `Xfiles`
- change description for `Polskie Filtry Elementów Irytujących` — there are non-English descriptions for other [Polish filters](https://uploads.adguard.com/slbdzd8lzc7h5.png) or [`RU AdList`, for example](https://uploads.adguard.com/slbdzd8l1ozjl.png) 
- mention that some filters are already included into other ones (EasyList, AdGuard Safari filter, EasyList Dutch, EasyList Germany, Liste FR)
- typos