### PR TITLE
Excluding unsupported options

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -10,13 +10,16 @@ replace=
 -abp-properties
 :xpath(
 (:scope
+$ping
 ! Exluding unsupported uBlock rules
 ##+js
+#@#+js
 ##script:inject
 $inline-script
 $inline-font
 ,inline-script
 ##^
+:watch-attr(
 ! Excluding redirect instructions
 $redirect=
 ,redirect=


### PR DESCRIPTION
There is also the following options, but unsure where to put them:

$1p
$3p
$beacon
$popunder  (from uBlock)

$popunder could maybe rewritten to $popup (if it does the same)