### PR TITLE
fix h5.17k.com

### DIFF
--- a/filters/ThirdParty/filter_104_EasyListChina/template.txt
+++ b/filters/ThirdParty/filter_104_EasyListChina/template.txt
@@ -1,6 +1,9 @@
 !
 @include "https://easylist-downloads.adblockplus.org/easylistchina.txt" /exclude="../../exclusions.txt"
 !
+! https://github.com/AdguardTeam/AdguardFilters/issues/47732
+!+ PLATFORM(ios, ext_safari)
+@@$script,subdocument,third-party,websocket,xmlhttprequest,domain=h5.17k.com
 ! https://github.com/AdguardTeam/AdguardFilters/issues/44417
 !+ PLATFORM(ios, ext_safari)
 @@||douban.com^$subdocument,domain=douban.com


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/47732

Since their filter dev cannot reproduce due to missing iOS (I cannot reproduce on my iPad either) and therefore is not removing the rule from wide block rule, whitelisting that rule.