### PR TITLE
PolskiFiltrAdg trusted high level and deflaut activate?

### DIFF
--- a/filters/ThirdParty/filter_238_PolskiFiltrAdg/metadata.json
+++ b/filters/ThirdParty/filter_238_PolskiFiltrAdg/metadata.json
@@ -9,8 +9,9 @@
   "groupId": 7,
   "subscriptionUrl": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock.txt",
   "tags": [
+    "recommended",
     "purpose:antiadblock",
     "lang:pl"
   ],
-  "trustLevel": "low"
+  "trustLevel": "high"
 }


### PR DESCRIPTION
See: 
https://github.com/AdguardTeam/AdguardFilters/issues/51118#issuecomment-596214305
https://github.com/AdguardTeam/AdguardFilters/issues/51118#issuecomment-596975486

If it is a lot suggested to activate it manually, it may have the recommended flag (assuming it is activated when visiting Polish language pages).

I guess we could use the Windows / macOS platform:

"`!+  NOT_PLATFORM( )`" instead of `badfilter` / `important` modifiers in the supplement.