### PR TITLE
Fix #322 - Added uBO-specific source to AdBlockID filter

### DIFF
--- a/filters/ThirdParty/filter_120_AdBlockID/template.txt
+++ b/filters/ThirdParty/filter_120_AdBlockID/template.txt
@@ -1,2 +1,3 @@
 !
 @include "https://raw.githubusercontent.com/realodix/AdBlockID/master/output/adblockid.txt" /exclude="../../exclusions.txt"
+@include "https://raw.githubusercontent.com/realodix/AdBlockID/master/output/adblockid-plus.txt" /exclude="../../exclusions.txt"


### PR DESCRIPTION
Also we can change `trustLevel` to `High` and make this filter recommended. It is maintained and does not causes issues.
https://github.com/AdguardTeam/FiltersRegistry/issues/235