### PR TITLE
Excluded $popup rule

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -44,6 +44,9 @@ $popup,~third-party
 !***  `exclusion`
 !
 !### Easylist ###
+! https://github.com/AdguardTeam/AdguardFilters/issues/55609
+! https://github.com/AdguardTeam/AdguardFilters/issues/55478#issuecomment-629828357
+/^https?:\/\/.*[&|%|+|=]/$popup,domain=
 ! https://github.com/AdguardTeam/AdguardForAndroid/issues/3438
 ! breaks the sites in AdGuard for Windows 7.3
 /^https:\/\/([a-z]+\.)?sythe\.org\/\[=%#@$&!^].*[\w\W]{20,}/$image


### PR DESCRIPTION
Excluded $popup rule, because it causes issues on some websites.

Examples:
https://github.com/AdguardTeam/AdguardFilters/issues/55609
https://github.com/AdguardTeam/AdguardFilters/issues/55478#issuecomment-629828357