### PR TITLE
Huge metadata fixing

### DIFF
--- a/filters/ThirdParty/filter_103_BulgarianList/metadata.json
+++ b/filters/ThirdParty/filter_103_BulgarianList/metadata.json
@@ -3,11 +3,11 @@
   "name": "Bulgarian list",
   "description": "Български supplement for EasyList.",
   "timeAdded": 1404115015843,
-  "homepage": "http://stanev.org/abp/",
+  "homepage": "https://stanev.org/abp/",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "http://stanev.org/abp/adblock_bg.txt",
+  "subscriptionUrl": "https://stanev.org/abp/adblock_bg.txt",
   "tags": [
     "purpose:ads",
     "reference:101",

--- a/filters/ThirdParty/filter_103_BulgarianList/template.txt
+++ b/filters/ThirdParty/filter_103_BulgarianList/template.txt
@@ -1,2 +1,2 @@
 !
-@include "http://stanev.org/abp/adblock_bg.txt" /exclude="../../exclusions.txt"
+@include "https://stanev.org/abp/adblock_bg.txt" /exclude="../../exclusions.txt"

--- a/filters/ThirdParty/filter_110_EasyListLithuania/metadata.json
+++ b/filters/ThirdParty/filter_110_EasyListLithuania/metadata.json
@@ -3,7 +3,7 @@
   "name": "EasyList Lithuania",
   "description": "Lietuvių kalba supplement for EasyList.",
   "timeAdded": 1404115015843,
-  "homepage": "http://margevicius.lt/",
+  "homepage": "https://github.com/EasyList-Lithuania/easylist_lithuania",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,

--- a/filters/ThirdParty/filter_113_ListeFR/metadata.json
+++ b/filters/ThirdParty/filter_113_ListeFR/metadata.json
@@ -3,7 +3,7 @@
   "name": "Liste FR",
   "description": "Français supplement for EasyList. Already included in AdGuard French filter.",
   "timeAdded": 1404115015843,
-  "homepage": "http://adblock-listefr.com/",
+  "homepage": "https://forums.lanik.us/viewforum.php?f=91",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,

--- a/filters/ThirdParty/filter_114_ROList/metadata.json
+++ b/filters/ThirdParty/filter_114_ROList/metadata.json
@@ -3,11 +3,11 @@
   "name": "ROList",
   "description": "Românesc supplement for EasyList.",
   "timeAdded": 1404115015843,
-  "homepage": "http://www.zoso.ro/rolist",
+  "homepage": "https://www.zoso.ro/rolist",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "http://www.zoso.ro/pages/rolist.txt",
+  "subscriptionUrl": "https://www.zoso.ro/pages/rolist.txt",
   "tags": [
     "purpose:ads",
     "reference:101",

--- a/filters/ThirdParty/filter_114_ROList/template.txt
+++ b/filters/ThirdParty/filter_114_ROList/template.txt
@@ -1,2 +1,2 @@
 !
-@include "http://www.zoso.ro/pages/rolist.txt" /exclude="../../exclusions.txt"
+@include "https://www.zoso.ro/pages/rolist.txt" /exclude="../../exclusions.txt"

--- a/filters/ThirdParty/filter_119_IcelandicABPList/metadata.json
+++ b/filters/ThirdParty/filter_119_IcelandicABPList/metadata.json
@@ -3,7 +3,7 @@
   "name": "Icelandic ABP List",
   "description": "Íslenska supplement for EasyList.",
   "timeAdded": 1404115015843,
-  "homepage": "http://adblock.gardar.net/",
+  "homepage": "https://adblock.gardar.net/",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,

--- a/filters/ThirdParty/filter_204_PeterLowesList/metadata.json
+++ b/filters/ThirdParty/filter_204_PeterLowesList/metadata.json
@@ -3,11 +3,11 @@
   "name": "Peter Lowe's Blocklist",
   "description": "Let us be blinked at no longer! Let the flashing cease! Down with banners! Up with transfer rates! STOP THE MADNESS!",
   "timeAdded": 1404115015843,
-  "homepage": "http://pgl.yoyo.org/adservers/",
+  "homepage": "https://pgl.yoyo.org/adservers/",
   "expires": "4 days",
   "displayNumber": 4,
   "groupId": 1,
-  "subscriptionUrl": "http://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&mimetype=plaintext",
+  "subscriptionUrl": "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&mimetype=plaintext",
   "tags": [
     "purpose:ads",
     "lang:en"

--- a/filters/ThirdParty/filter_205_SchacksAdblockPlusListe/metadata.json
+++ b/filters/ThirdParty/filter_205_SchacksAdblockPlusListe/metadata.json
@@ -3,11 +3,11 @@
   "name": "(Obsolete) Schacks Adblock Plus liste",
   "description": "dansk",
   "timeAdded": 1404115015843,
-  "homepage": "http://henrik.schack.dk/adblock/",
+  "homepage": "https://henrik.schack.dk/adblock/",
   "expires": "4 days",
   "displayNumber": 100,
   "groupId": 7,
-  "subscriptionUrl": "http://adblock.schack.dk/block.txt",
+  "subscriptionUrl": "https://adblock.dk/block.csv",
   "tags": [
     "purpose:ads",
     "lang:da",

--- a/filters/ThirdParty/filter_205_SchacksAdblockPlusListe/template.txt
+++ b/filters/ThirdParty/filter_205_SchacksAdblockPlusListe/template.txt
@@ -1,2 +1,2 @@
 !
-@include "http://adblock.dk/block.csv" /exclude="../../exclusions.txt"
+@include "https://adblock.dk/block.csv" /exclude="../../exclusions.txt"

--- a/filters/ThirdParty/filter_210_Spam404/metadata.json
+++ b/filters/ThirdParty/filter_210_Spam404/metadata.json
@@ -3,7 +3,7 @@
   "name": "Spam404",
   "description": "This filter protects you from online scams.",
   "timeAdded": 1404115015843,
-  "homepage": "http://www.spam404.com/",
+  "homepage": "https://www.spam404.com/",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 5,

--- a/filters/ThirdParty/filter_214_ABPVNList/metadata.json
+++ b/filters/ThirdParty/filter_214_ABPVNList/metadata.json
@@ -3,7 +3,7 @@
   "name": "ABPVN List",
   "description": "Vietnamese adblock filter list.",
   "timeAdded": 1404115015843,
-  "homepage": "http://abpvn.com/",
+  "homepage": "https://abpvn.com/",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,

--- a/filters/ThirdParty/filter_218_EstonianList/metadata.json
+++ b/filters/ThirdParty/filter_218_EstonianList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 218,
   "name": "Estonian List",
-  "description": "Estonian filterlist",
+  "description": "Filter for ad blocking on Estonian sites",
   "timeAdded": 1404115015843,
   "homepage": "https://adblock.ee/",
   "expires": "4 days",

--- a/filters/ThirdParty/filter_218_EstonianList/metadata.json
+++ b/filters/ThirdParty/filter_218_EstonianList/metadata.json
@@ -1,13 +1,13 @@
 {
   "filterId": 218,
   "name": "Estonian List",
-  "description": "Estonian filtr",
+  "description": "Estonian filterlist",
   "timeAdded": 1404115015843,
-  "homepage": "http://adblock.ee/",
+  "homepage": "https://adblock.ee/",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "http://adblock.ee/list.php",
+  "subscriptionUrl": "https://adblock.ee/list.php",
   "tags": [
     "purpose:ads",
     "lang:et"

--- a/filters/ThirdParty/filter_218_EstonianList/template.txt
+++ b/filters/ThirdParty/filter_218_EstonianList/template.txt
@@ -1,2 +1,2 @@
 !
-@include "http://adblock.ee/list.php" /exclude="../../exclusions.txt"
+@include "https://adblock.ee/list.php" /exclude="../../exclusions.txt"

--- a/filters/ThirdParty/filter_219_ChinaListAndEasyList/metadata.json
+++ b/filters/ThirdParty/filter_219_ChinaListAndEasyList/metadata.json
@@ -1,13 +1,13 @@
 {
   "filterId": 219,
-  "name": "ChinaList+EasyList",
-  "description": "China List and Easy List",
+  "name": "ADT ChinaList",
+  "description": "Adblocking list for PR-China",
   "timeAdded": 1404115015843,
-  "homepage": "http://www.adtchrome.com/extension/adt-chinalist-easylist.html",
+  "homepage": "https://www.adtchrome.com/",
   "expires": "4 days",
   "displayNumber": 100,
   "groupId": 7,
-  "subscriptionUrl": "http://sub.adtchrome.com/adt-chinalist-easylist.txt",
+  "subscriptionUrl": "https://sub.adtchrome.com/adt-chinalist-easylist.txt",
   "tags": [
     "purpose:ads",
     "reference:101",

--- a/filters/ThirdParty/filter_219_ChinaListAndEasyList/metadata.json
+++ b/filters/ThirdParty/filter_219_ChinaListAndEasyList/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 219,
-  "name": "ADT ChinaList",
-  "description": "Adblocking list for PR-China",
+  "name": "ChinaList+EasyList",
+  "description": "Adblocking list for China. Note that it does not actually include EasyList.",
   "timeAdded": 1404115015843,
   "homepage": "https://www.adtchrome.com/",
   "expires": "4 days",

--- a/filters/ThirdParty/filter_219_ChinaListAndEasyList/template.txt
+++ b/filters/ThirdParty/filter_219_ChinaListAndEasyList/template.txt
@@ -1,2 +1,2 @@
 !
-@include "http://sub.adtchrome.com/adt-chinalist-easylist.txt" /exclude="../../exclusions.txt"
+@include "https://sub.adtchrome.com/adt-chinalist-easylist.txt" /exclude="../../exclusions.txt"

--- a/filters/ThirdParty/filter_222_ABPPersian/metadata.json
+++ b/filters/ThirdParty/filter_222_ABPPersian/metadata.json
@@ -3,11 +3,11 @@
   "name": "Adblock-Persian list",
   "description": "Adblock-Persian list",
   "timeAdded": 1404115015843,
-  "homepage": "http://ideone.com/K452p",
+  "homepage": "https://ideone.com/K452p",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "http://ideone.com/plain/K452p",
+  "subscriptionUrl": "https://ideone.com/plain/K452p",
   "tags": [
     "purpose:ads",
     "lang:fa"

--- a/filters/ThirdParty/filter_223_FanboySwedish/metadata.json
+++ b/filters/ThirdParty/filter_223_FanboySwedish/metadata.json
@@ -10,7 +10,8 @@
   "subscriptionUrl": "https://www.fanboy.co.nz/fanboy-swedish.txt",
   "tags": [
     "purpose:ads",
-    "lang:sv"
+    "lang:sv",
+    "obsolete"
   ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_223_FanboySwedish/metadata.json
+++ b/filters/ThirdParty/filter_223_FanboySwedish/metadata.json
@@ -3,7 +3,7 @@
   "name": "Fanboy's Swedish",
   "description": "Fanboy's Swedish",
   "timeAdded": 1404115015843,
-  "homepage": "http://www.fanboy.co.nz/",
+  "homepage": "https://www.fanboy.co.nz/",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,

--- a/filters/ThirdParty/filter_223_FanboySwedish/metadata.json
+++ b/filters/ThirdParty/filter_223_FanboySwedish/metadata.json
@@ -1,6 +1,6 @@
 {
   "filterId": 223,
-  "name": "(Obsolete) Fanboy's Swedish",
+  "name": "Fanboy's Swedish",
   "description": "Fanboy's Swedish",
   "timeAdded": 1404115015843,
   "homepage": "https://www.fanboy.co.nz/",
@@ -10,8 +10,7 @@
   "subscriptionUrl": "https://www.fanboy.co.nz/fanboy-swedish.txt",
   "tags": [
     "purpose:ads",
-    "lang:sv",
-    "obsolete"
+    "lang:sv"
   ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_223_FanboySwedish/metadata.json
+++ b/filters/ThirdParty/filter_223_FanboySwedish/metadata.json
@@ -1,6 +1,6 @@
 {
   "filterId": 223,
-  "name": "Fanboy's Swedish",
+  "name": "(Obsolete) Fanboy's Swedish",
   "description": "Fanboy's Swedish",
   "timeAdded": 1404115015843,
   "homepage": "https://www.fanboy.co.nz/",

--- a/filters/ThirdParty/filter_225_fanboyAntifacebook/metadata.json
+++ b/filters/ThirdParty/filter_225_fanboyAntifacebook/metadata.json
@@ -1,9 +1,9 @@
 {
   "filterId": 225,
   "name": "Fanboy Anti-Facebook List",
-  "description": "Warning, will break on facebook-based comment sites and may also break on some facebook apps or games.",
+  "description": "Warning, will break on Facebook-based comment sites and may also break on some Facebook apps or games.",
   "timeAdded": 1404115015843,
-  "homepage": "http://www.fanboy.co.nz",
+  "homepage": "https://www.fanboy.co.nz",
   "expires": "4 days",
   "displayNumber": 4,
   "groupId": 2,

--- a/filters/ThirdParty/filter_226_FanboyVietnamese/metadata.json
+++ b/filters/ThirdParty/filter_226_FanboyVietnamese/metadata.json
@@ -3,7 +3,7 @@
   "name": "Fanboy's Vietnamese",
   "description": "Fanboy's Vietnamese",
   "timeAdded": 1404115015843,
-  "homepage": "http://www.fanboy.co.nz/",
+  "homepage": "https://www.fanboy.co.nz/",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,

--- a/filters/ThirdParty/filter_230_FanboyEspanol/metadata.json
+++ b/filters/ThirdParty/filter_230_FanboyEspanol/metadata.json
@@ -1,18 +1,17 @@
 {
   "filterId": 230,
-  "name": "(Obsolete) Fanboy's Spanish/Portuguese",
+  "name": "Fanboy's Spanish/Portuguese",
   "description": "Fanboy's Spanish/Portuguese",
   "timeAdded": 1404115015843,
   "homepage": "https://www.fanboy.co.nz/",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "https://www.fanboy.co.nz/fanboy-espanol.txt",
+  "subscriptionUrl": "https://fanboy.co.nz/fanboy-espanol.txt",
   "tags": [
     "purpose:ads",
     "lang:es",
-    "lang:pt",
-    "obsolete"
+    "lang:pt"
   ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_230_FanboyEspanol/metadata.json
+++ b/filters/ThirdParty/filter_230_FanboyEspanol/metadata.json
@@ -3,14 +3,15 @@
   "name": "FanboyEspanol",
   "description": "Fanboys Spanish/Portuguese",
   "timeAdded": 1404115015843,
-  "homepage": "https://adblockplus.org/subscriptions",
+  "homepage": "https://www.fanboy.co.nz/",
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "http://fanboy.co.nz/fanboy-espanol.txt",
+  "subscriptionUrl": "https://www.fanboy.co.nz/fanboy-espanol.txt",
   "tags": [
     "purpose:ads",
-    "lang:es"
+    "lang:es",
+    "lang:pt"
   ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_230_FanboyEspanol/metadata.json
+++ b/filters/ThirdParty/filter_230_FanboyEspanol/metadata.json
@@ -1,6 +1,6 @@
 {
   "filterId": 230,
-  "name": "Fanboy's Spanish/Portuguese",
+  "name": "(Obsolete) Fanboy's Spanish/Portuguese",
   "description": "Fanboy's Spanish/Portuguese",
   "timeAdded": 1404115015843,
   "homepage": "https://www.fanboy.co.nz/",

--- a/filters/ThirdParty/filter_230_FanboyEspanol/metadata.json
+++ b/filters/ThirdParty/filter_230_FanboyEspanol/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 230,
-  "name": "FanboyEspanol",
-  "description": "Fanboys Spanish/Portuguese",
+  "name": "Fanboy's Spanish/Portuguese",
+  "description": "Fanboy's Spanish/Portuguese",
   "timeAdded": 1404115015843,
   "homepage": "https://www.fanboy.co.nz/",
   "expires": "4 days",
@@ -11,7 +11,8 @@
   "tags": [
     "purpose:ads",
     "lang:es",
-    "lang:pt"
+    "lang:pt",
+    "obsolete"
   ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_230_FanboyEspanol/template.txt
+++ b/filters/ThirdParty/filter_230_FanboyEspanol/template.txt
@@ -1,2 +1,2 @@
 !
-@include "http://fanboy.co.nz/fanboy-espanol.txt" /exclude="../../exclusions.txt"
+@include "https://www.fanboy.co.nz/fanboy-espanol.txt" /exclude="../../exclusions.txt"

--- a/filters/ThirdParty/filter_230_FanboyEspanol/template.txt
+++ b/filters/ThirdParty/filter_230_FanboyEspanol/template.txt
@@ -1,2 +1,2 @@
 !
-@include "https://www.fanboy.co.nz/fanboy-espanol.txt" /exclude="../../exclusions.txt"
+@include "https://fanboy.co.nz/fanboy-espanol.txt" /exclude="../../exclusions.txt"

--- a/filters/ThirdParty/filter_239_FanboyAntifonts/metadata.json
+++ b/filters/ThirdParty/filter_239_FanboyAntifonts/metadata.json
@@ -3,7 +3,7 @@
   "name": "Fanboy's Anti-thirdparty Fonts",
   "description": "A filter to block third-party fonts. It may break the look and design of some websites.",
   "timeAdded": 1404115015843,
-  "homepage": "http://www.fanboy.co.nz/",
+  "homepage": "https://www.fanboy.co.nz/",
   "expires": "4 days",
   "displayNumber": 5,
   "groupId": 2,

--- a/filters/ThirdParty/filter_241_FanboyCookiemonster/metadata.json
+++ b/filters/ThirdParty/filter_241_FanboyCookiemonster/metadata.json
@@ -3,7 +3,7 @@
   "name": "EasyList Cookie List",
   "description": "Removes cookie and privacy warnings. Already included in Fanboy's Annoyances list.",
   "timeAdded": 1404115015843,
-  "homepage": "http://www.fanboy.co.nz/",
+  "homepage": "https://easylist.to/",
   "expires": "4 days",
   "displayNumber": 5,
   "groupId": 4,


### PR DESCRIPTION
Inspired by #334, I decided to fix and improve the metadata of a whole slew of lists in this repo.

Most affected were "ChinaList+EasyList" (now renamed "ADT ChinaList" by me, as it does not actually include EasyList), and "Fanboy's Spanish/Portuguese". However, around 20 other lists also saw their links be changed from HTTP to HTTPS, or even replaced entirely (e.g. in Liste FR's case).

I also marked "Fanboy's Swedish" and "Fanboy's Spanish/Portuguese" as obsolete, IIRC, as they had been marked as discontinued for more than 12 months; and rewrote some particularly odd-looking descriptions.