### PR TITLE
Temporary disabled Web Annoyances Ultralist due to incompatible '!#include' directive

### DIFF
--- a/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
+++ b/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
@@ -11,5 +11,6 @@
   "tags": [
     "purpose:annoyances"
   ],
-  "trustLevel": "high"
+  "trustLevel": "high",
+  "disabled": true
 }


### PR DESCRIPTION
look at our chat for details.
```
! syntax for latest ubo 1.27.5b1 on firefox
!#include filters/css_companion_filters.txt
!syntax fo all other blockers
!#include css_companion_filters.txt
```