### PR TITLE
Corrected the "subscriptionUrl" link for my Nordic list

### DIFF
--- a/filters/ThirdParty/filter_249_NorwegianList/metadata.json
+++ b/filters/ThirdParty/filter_249_NorwegianList/metadata.json
@@ -7,7 +7,7 @@
   "expires": "4 days",
   "displayNumber": 249,
   "groupId": 7,
-  "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianList.txt",
+  "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/NordicFiltersAdGuard.txt",
   "tags": [
     "recommended",
     "purpose:ads",


### PR DESCRIPTION
While fiddling around with AdGuard for Android during a bus ride today, I noticed that it still showed the link to the uBO list version on the list info screen (as seen in the screenshot below), instead of the AdGuard list version. So I've attempted to correct that now.

![image](https://user-images.githubusercontent.com/22780683/92103894-dded6000-ede0-11ea-858c-3b0fc844e291.png)