### PR TITLE
fix abp exclusions

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -6,10 +6,8 @@
 ! #@%# - processed by trust-levels
 ! replace= - processed by trust-levels
 ! Exluding unsupported ABP rules
-#$#abort-current-inline-script
+! https://github.com/AdguardTeam/ExtendedCss/issues/6#issuecomment-242328295
 -abp-properties
-:xpath(
-(:scope
 ! Exluding unsupported uBlock rules
 ! ##+js - processed by trust-levels
 ! ##script:inject - processed by trust-levels


### PR DESCRIPTION
`#$#abort-current-inline-script` — https://github.com/AdguardTeam/FiltersCompiler/issues/39

`scope` — [implemented](https://github.com/AdguardTeam/ExtendedCss/commit/925fc0170a9c8f2b4589256b34fa80d451cd1919#diff-6fd8b7afbef18123352836aedc684f8598fc9b87cfb4538f4297de1acdcc16ef) 6 weeks ago 

`xpath` — [implemented](https://github.com/AdguardTeam/ExtendedCss/blob/2029ff07758ee2fe3dd0be688991cc05cf5e7857/lib/extended-css-selector.js#L38) as well 