### PR TITLE
fix #66624 kaspersky.com

### DIFF
--- a/filters/ThirdParty/filter_215_FanboysEnancedTrackingList/template.txt
+++ b/filters/ThirdParty/filter_215_FanboysEnancedTrackingList/template.txt
@@ -1,2 +1,6 @@
 !
 @include "https://secure.fanboy.co.nz/enhancedstats.txt" /exclude="../../exclusions.txt"
+!
+! https://github.com/AdguardTeam/AdguardFilters/issues/66624
+!+ PLATFORM(mac, windows, android)
+@@||media.kaspersky.com/tracking/omniture/s_code_single_suite.js


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/66624

The rule `/s_code_`  from Fanboy Enhanced Tracking list breaks kaspersky.com only in programs for mac, windows, android.