### PR TITLE
temporary disable 249th filter

### DIFF
--- a/filters/ThirdParty/filter_249_NorwegianList/metadata.json
+++ b/filters/ThirdParty/filter_249_NorwegianList/metadata.json
@@ -17,5 +17,6 @@
     "lang:is",
     "lang:fo"
   ],
-  "trustLevel": "high"
+  "trustLevel": "high",
+  "disabled": true
 }


### PR DESCRIPTION
filters build fails:
https://uploads.adguard.com/slbdzdrjdnep.png

because of invalid include path :
```
!#if env_legacy
!#include uBO%20list%20extensions/TemporaryWaterfoxClassicFixForNordicFilters.txt
!#endif
```

I've already reported:
https://github.com/DandelionSprout/adfilt/issues/135

but if fix will take too long, maybe it would be better not to wait for it and temporary disable the filter (build have been failing since 22-Nov-2020 08:02:19)
