### PR TITLE
Excluded rules from RU AdList and ChinaList+EasyList

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -206,7 +206,15 @@ _campaign=$popup
 ! End: Prebake
 !################
 !
+!### ChinaList+EasyList ###
+! https://github.com/AdguardTeam/SafariConverterLib/issues/4
+/g\.alicdn\.com\/mm\/yksdk\/0\.2\.\d+\/playersdk\.js/
+! End: ChinaList+EasyList
+!################
+!
 !### RU AdList ###
+! https://github.com/AdguardTeam/SafariConverterLib/issues/4
+||xyz^$third-party,script,xmlhttprequest,domain=
 ! censor.net.ua - site is blocked in Safari($subdocument is not supported)
 ||censor.net.ua^$subdocument,domain=censor.net.ua
 ! https://github.com/AdguardTeam/ExperimentalFilter/issues/1430


### PR DESCRIPTION
https://github.com/AdguardTeam/SafariConverterLib/issues/4
First rule `||gamer.no/?module=Tumedia\DFProxy\Modules^`  was excluded via `$badfilter` here https://github.com/AdguardTeam/AdguardFilters/commit/8e83de3e7503adec5d3c819b737d2fe9e2f78e80
The rest of them are here, please check if they are correct.