### PR TITLE
Excluded Google Contributor anti-adblock baits

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -56,6 +56,9 @@ $popup,~third-party
 /^##\.myTestAd$/
 /^##\.adsbox$/
 /adframe.
+! Excluding Google Contributor anti-adblock baits
+/^##div\[class\^="div-gpt-ad"\]$/
+/^##\.div-gpt-ad$/
 ! https://github.com/easylist/easylist/commit/e2efe2c3686cf6192f4e2d6a944ebe092c06f27a
 ! Excluding the rule which breaks youtube embedded video player
 ||youtube.com/get_video_info?$domain=youtube.com


### PR DESCRIPTION
For example here - https://github.com/AdguardTeam/AdguardFilters/issues/77053
If `fundingchoicesmessages.google.com` is blocked and `div-gpt-ad` element is hidden then anti-adblock notice is displayed.
```
<div class="div-gpt-ad" style="width: 1px; height: 1px; position: absolute; left: -10000px; top: -10000px; z-index: -10000;"></div>
```