### PR TITLE
Excluded Google Contributor anti-adblock baits

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -57,6 +57,7 @@ $popup,~third-party
 /^##\.adsbox$/
 /adframe.
 ! Excluding Google Contributor anti-adblock baits
+/^##\[class\^="div-gpt-ad"\]$/
 /^##div\[class\^="div-gpt-ad"\]$/
 /^##\.div-gpt-ad$/
 ! https://github.com/easylist/easylist/commit/e2efe2c3686cf6192f4e2d6a944ebe092c06f27a


### PR DESCRIPTION
Related to this - https://github.com/AdguardTeam/FiltersRegistry/pull/435
This rule `##[class^="div-gpt-ad"]` was added recently - https://github.com/easylist/easylist/commit/1320348c12e4718e486b10649fd819040bcd53c2
`div[class^="div-gpt-ad"]` is still in `Liste FR`, so shouldn't be removed.
