### PR TITLE
Exclude redundant regex in EasyList China

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -220,7 +220,7 @@ _campaign=$popup
 !################
 !
 !### ChinaList+EasyList ###
-! redundant by /^https?:\/\/([a-z0-9]{8,10}\.)?[a-z0-9-]{5,}\.(com|bid|link|online|top|club)\/([a-z0-9]{2}\/){3}[a-f0-9]{32}\.js/$script,third-party in Base
+! https://github.com/AdguardTeam/FiltersRegistry/pull/481
 /\.com\/[0-9a-z]{2}\/[0-9a-z]{2}\/[0-9a-z]{2}\/[0-9a-z]{32}\.js/$script,third-party
 ! https://github.com/AdguardTeam/SafariConverterLib/issues/4
 /g\.alicdn\.com\/mm\/yksdk\/0\.2\.\d+\/playersdk\.js/

--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -220,6 +220,8 @@ _campaign=$popup
 !################
 !
 !### ChinaList+EasyList ###
+! redundant by /^https?:\/\/([a-z0-9]{8,10}\.)?[a-z0-9-]{5,}\.(com|bid|link|online|top|club)\/([a-z0-9]{2}\/){3}[a-f0-9]{32}\.js/$script,third-party in Base
+/\.com\/[0-9a-z]{2}\/[0-9a-z]{2}\/[0-9a-z]{2}\/[0-9a-z]{32}\.js/$script,third-party
 ! https://github.com/AdguardTeam/SafariConverterLib/issues/4
 /g\.alicdn\.com\/mm\/yksdk\/0\.2\.\d+\/playersdk\.js/
 ! End: ChinaList+EasyList


### PR DESCRIPTION
`/\.com\/[0-9a-z]{2}\/[0-9a-z]{2}\/[0-9a-z]{2}\/[0-9a-z]{32}\.js/$script,third-party` in EL China is made redundant by `/^https?:\/\/([a-z0-9]{8,10}\.)?[a-z0-9-]{5,}\.(com|bid|link|online|top|club)\/([a-z0-9]{2}\/){3}[a-f0-9]{32}\.js/$script,third-party` in Base so should be excluded just like done in French list.