### PR TITLE
Excluded old BAB bait

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -44,6 +44,7 @@ $popup,~third-party
 !
 !### Anti-adblock baits ###
 ! all filters
+/###banner_ad$/
 /^##\.adsbox$/
 /^##\.afs_ads$/
 !


### PR DESCRIPTION
original rule is absent in Easylist, exists in Bulgarian only.
After that, elemhide exclusions could be removed.