### PR TITLE
Update adguard-filters-compiler to v1.1.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Adguard filters compiler",
   "homepage": "http://adguard.com",
   "dependencies": {
-    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.22"
+    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.23"
   },
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,9 +51,9 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.22":
-  version "1.1.22"
-  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#98b228cf0786b3b41dfd2f65937270c80ecc69a7"
+"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.23":
+  version "1.1.23"
+  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#505cde7b867192b69c5646e3cae4a55bd4dfab67"
   dependencies:
     "@adguard/tsurlfilter" "0.5.9"
     ajv "^6.10.2"


### PR DESCRIPTION
[adguard-filters-compiler](https://github.com/AdguardTeam/FiltersCompiler/releases/tag/v1.1.23) with !#safari_cb_affinity validation