### PR TITLE
Fanboys Annoyances - subscription url

### DIFF
--- a/filters/ThirdParty/filter_122_FanboysAnnoyances/metadata.json
+++ b/filters/ThirdParty/filter_122_FanboysAnnoyances/metadata.json
@@ -7,7 +7,7 @@
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 4,
-  "subscriptionUrl": "https://easylist-downloads.adblockplus.org/fanboy-annoyance.txt",
+  "subscriptionUrl": "https://easylist.to/easylist/fanboy-annoyance.txt",
   "tags": [
     "purpose:annoyances",
     "reference:101"

--- a/filters/ThirdParty/filter_122_FanboysAnnoyances/template.txt
+++ b/filters/ThirdParty/filter_122_FanboysAnnoyances/template.txt
@@ -1,5 +1,5 @@
 !
-@include "https://easylist.github.io/easylist/fanboy-annoyance.txt" /exclude="../../exclusions.txt"
+@include "https://easylist.to/easylist/fanboy-annoyance.txt" /exclude="../../exclusions.txt"
 !
 ! https://github.com/AdguardTeam/AdguardFilters/issues/75860
 !+ PLATFORM(ios, ext_safari)


### PR DESCRIPTION
This `https://easylist-downloads.adblockplus.org/fanboy-annoyance.txt` returns `404` error.