### PR TITLE
Fix EasyList Cookie List - bad rule

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -264,5 +264,10 @@ _campaign=$popup
 /^##\.ad$/
 !###############
 !
+!### EasyList Cookie List ###
+! Filters fails to build in AdGuard for Safari
+northernpowergrid.com##+js(remove-class, blur, , html)
+!###############
+!
 !----- TEMPORARY -----
 !----- TEMPORARY -----


### PR DESCRIPTION
Filters fails to build in AdGuard for Safari