### PR TITLE
Revert "Fix EasyList Cookie List - bad rule"

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -264,10 +264,5 @@ _campaign=$popup
 /^##\.ad$/
 !###############
 !
-!### EasyList Cookie List ###
-! Filters fails to build in AdGuard for Safari
-northernpowergrid.com##+js(remove-class, blur, , html)
-!###############
-!
 !----- TEMPORARY -----
 !----- TEMPORARY -----


### PR DESCRIPTION
Reverts AdguardTeam/FiltersRegistry#578
Fixed by filter's author
https://github.com/easylist/easylist/commit/1f87ac36cc1eee6d84e7ec1add7897d77f02beba