### PR TITLE
Excluded old only invalid rules. Disabled obsolete filters

### DIFF
--- a/filters/ThirdParty/filter_200_ABPJapaneseFilters/metadata.json
+++ b/filters/ThirdParty/filter_200_ABPJapaneseFilters/metadata.json
@@ -15,5 +15,6 @@
     "problematic",
     "obsolete"
   ],
-  "trustLevel": "low"
+  "trustLevel": "low",
+  "disabled": true
 }

--- a/filters/ThirdParty/filter_200_ABPJapaneseFilters/template.txt
+++ b/filters/ThirdParty/filter_200_ABPJapaneseFilters/template.txt
@@ -1,13 +1,3 @@
 !
 @include "https://raw.githubusercontent.com/k2jp/abp-japanese-filters/master/abpjf.txt" /exclude="../../exclusions.txt"
 @include "https://raw.githubusercontent.com/k2jp/abp-japanese-filters/master/abpjf_element_hiding.txt" /exclude="../../exclusions.txt"
-!
-! https://github.com/AdguardTeam/AdguardFilters/issues/34795#issuecomment-544906454
-twitter.com#@#[class*="-ad9"]:not(:root):not(body):not(input)
-! https://github.com/AdguardTeam/AdguardFilters/issues/24979
-@@||cdns.gigya.com/js/gigya.js$domain=tf1.fr
-! https://github.com/AdguardTeam/ExperimentalFilter/issues/1686
-! fixing Google Music
-@@|http:*?*&ip=$domain=play.google.com
-! blocks useful popups(like chat with the seller)
-@@||aliexpress.com^

--- a/filters/ThirdParty/filter_205_SchacksAdblockPlusListe/metadata.json
+++ b/filters/ThirdParty/filter_205_SchacksAdblockPlusListe/metadata.json
@@ -13,5 +13,6 @@
     "lang:da",
     "obsolete"
   ],
-  "trustLevel": "low"
+  "trustLevel": "low",
+  "disabled": true
 }

--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -267,7 +267,6 @@ _campaign=$popup
 ||www.dwrean.net##iframe[src="http://kratisinow.digitup.eu/widget/widget-artists"]
 !
 ! Xfiles
-||the-japan-news.com/modules/js/lib/fgp/fingerprint2.js$script,redirect=fingerprint2.js,important
 ||widgets.outbrain.com/outbrain.js$script,redirect=widgets.outbrain.com/outbrain.js
 @@##.qc-cmp2-container$domain=~ilbianconero.com
 @@##.qc-cmp2-main$domain=~ilbianconero.com

--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -238,12 +238,6 @@ _campaign=$popup
 ! End: RU AdList
 !#################
 !
-!### void.gr ###
-! Invalid rules
-||www.dwrean.net##a[href="http://www.kratisinow.gr"]
-||www.dwrean.net##iframe[src="http://kratisinow.digitup.eu/widget/widget-artists"]
-!###############
-!
 !### Korean Adblock List ###
 ||yandex.ru^$third-party
 !###########################
@@ -263,6 +257,31 @@ _campaign=$popup
 ! https://github.com/AdguardTeam/AdguardFilters/issues/84173
 /^##\.ad$/
 !###############
+!
+!
+!### Invalid rules ###
+! This section is for known old invalid rules
+!
+! void.gr
+||www.dwrean.net##a[href="http://www.kratisinow.gr"]
+||www.dwrean.net##iframe[src="http://kratisinow.digitup.eu/widget/widget-artists"]
+!
+! Xfiles
+||the-japan-news.com/modules/js/lib/fgp/fingerprint2.js$script,redirect=fingerprint2.js,important
+||widgets.outbrain.com/outbrain.js$script,redirect=widgets.outbrain.com/outbrain.js
+@@##.qc-cmp2-container$domain=~ilbianconero.com
+@@##.qc-cmp2-main$domain=~ilbianconero.com
+@@###qc-cmp2-main$domain=~ilbianconero.com
+!
+! Deprecated $collapse and $object-subrequest modifiers
+! https://blog.adblockplus.org/development-builds/removed-support-for-the-collapse-and-object-subrequest-filter-options
+$collapse
+$~collapse
+,~collapse
+$object-subrequest
+$~object-subrequest
+,object-subrequest
+!#####################
 !
 !----- TEMPORARY -----
 !----- TEMPORARY -----


### PR DESCRIPTION
Excluded old only invalid rules. Disabled ABP Japanese Filter, Schacks Adblock Plus liste.

Added to exclusions.txt, because there are many unnecessary lines about invalide rules.