### PR TITLE
Fix znctrack.net https://github.com/AdguardTeam/AdguardFilters/issues/112370

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -150,6 +150,8 @@ biggestplayer.me##.adblock1
 !
 !### EasyPrivacy ###
 /generate_204$
+! https://github.com/AdguardTeam/AdguardFilters/issues/112370
+||znctrack.net^$third-party
 ! End: EasyPrivacy
 !###################
 !


### PR DESCRIPTION
Blocking causes ads reinjection on some Ukrainian sites.