### PR TITLE
Exclude replace temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Adguard filters compiler",
   "homepage": "http://adguard.com",
   "dependencies": {
-    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.38"
+    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.44"
   },
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
disabled `$$` and `replace` rules for Firefox extension