### PR TITLE
Removed obsolete file filter_14_Annoyances/remains.txt

### DIFF
--- a/filters/filter_14_Annoyances/template.txt
+++ b/filters/filter_14_Annoyances/template.txt
@@ -18,7 +18,6 @@
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/AnnoyancesFilter/sections/mobile-app.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/AnnoyancesFilter/sections/popups.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/AnnoyancesFilter/sections/push-notifications.txt"
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/AnnoyancesFilter/sections/remains.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/AnnoyancesFilter/sections/self-promo.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/AnnoyancesFilter/sections/subscriptions.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/AnnoyancesFilter/sections/tweaks.txt"


### PR DESCRIPTION
TODO: Remove `\AdguardFilters\AnnoyancesFilter\sections\remains.txt` from filters after next filters build.