### PR TITLE
Revert "temporary disabled the filter (#618)"

### DIFF
--- a/filters/ThirdParty/filter_111_LatvianList/metadata.json
+++ b/filters/ThirdParty/filter_111_LatvianList/metadata.json
@@ -14,6 +14,5 @@
     "recommended",
     "lang:lv"
   ],
-  "trustLevel": "high",
-  "disabled": true
+  "trustLevel": "high"
 }


### PR DESCRIPTION
This reverts commit 9103f0298fc709703357ba42a9170dfbbae50dc6.

It seems this filter is available again.