### PR TITLE
Added recommended tags for two filters: `Persian Blocker` and `Estonian List`

### DIFF
--- a/filters/ThirdParty/filter_218_EstonianList/metadata.json
+++ b/filters/ThirdParty/filter_218_EstonianList/metadata.json
@@ -9,6 +9,7 @@
   "groupId": 7,
   "subscriptionUrl": "https://adblock.ee/list.php",
   "tags": [
+    "recommended",
     "purpose:ads",
     "lang:et"
   ],

--- a/filters/ThirdParty/filter_235_PersianBlocker/metadata.json
+++ b/filters/ThirdParty/filter_235_PersianBlocker/metadata.json
@@ -9,6 +9,7 @@
   "groupId": 7,
   "subscriptionUrl": "https://raw.githubusercontent.com/MasterKia/PersianBlocker/main/PersianBlocker.txt",
   "tags": [
+    "recommended",
     "purpose:ads",
     "lang:fa"
   ],


### PR DESCRIPTION
It is needed to automatically turn on these filters when a user visits sites.
