### PR TITLE
Add blank between words to japanse translation

### DIFF
--- a/locales/ja/filters.json
+++ b/locales/ja/filters.json
@@ -20,7 +20,7 @@
 		"filter.5.description": "特定の危険なフィルタリングルールを基本フィルタに追加する前にテストするように設計されたフィルタです。"
 	},
 	{
-		"filter.6.name": "AdGuardドイツ語フィルタ",
+		"filter.6.name": "AdGuard ドイツ語フィルタ",
 		"filter.6.description": "EasyList GermanyとAdGuardドイツ語フィルタの合同。ドイツ語のウェブ広告を除去するフィルタリストです。"
 	},
 	{
@@ -28,7 +28,7 @@
 		"filter.7.description": "日本語のWebサイトで広告ブロックを有効にするフィルタです。"
 	},
 	{
-		"filter.8.name": "AdGuardオランダ語フィルタ",
+		"filter.8.name": "AdGuard オランダ語フィルタ",
 		"filter.8.description": "EasyList DutchとAdGuardオランダ語フィルタの合同。オランダ語のウェブ広告を除去するフィルタリストです。"
 	},
 	{
@@ -48,7 +48,7 @@
 		"filter.12.description": "iOSとOS X上のSafari 9以降のための専用フィルター。Safariはルール構文を完全にサポートしていないため、独自のフィルターが必要です。"
 	},
 	{
-		"filter.13.name": "AdGuardトルコ語フィルタ",
+		"filter.13.name": "AdGuard トルコ語フィルタ",
 		"filter.13.description": "トルコ語のWebサイトの広告を特に削除するフィルタリストです。"
 	},
 	{
@@ -88,7 +88,7 @@
 		"filter.22.description": "オンラインアシスタント、ライブサポートチャットなど、迷惑なサードパーティウィジェットをブロックします。"
 	},
 	{
-		"filter.224.name": "AdGuard中国語フィルタ",
+		"filter.224.name": "AdGuard 中国語フィルタ",
 		"filter.224.description": "EasyList China + AdGuard中国語フィルター。中国語のウェブサイトに掲載されている広告を除去するフィルタリストです。"
 	},
 	{


### PR DESCRIPTION
I think it strange that there is a difference in the presence or absence of spaces for each language specific filters.