### PR TITLE
Remove unnecessary rule

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -241,8 +241,6 @@ _campaign=$popup
 !### xinggsf ###
 /##\.adsbygoogle,\.ads$/
 */market-$script
-! https://github.com/xinggsf/Adblock-Plus-Rule/issues/52
-||p2p.$xmlhttprequest,websocket,ping,domain=~huya.com
 ! https://github.com/xinggsf/Adblock-Plus-Rule/issues/23
 ||acs.$domain=~youku.com|~tudou.com
 !###############


### PR DESCRIPTION
Looks like it's not needed due to the fix there https://github.com/xinggsf/Adblock-Plus-Rule/issues/52.