### PR TITLE
Removed obsolete esclusions for uBO's CSP rules

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -8,12 +8,6 @@
 ! Exluding unsupported ABP rules
 ! https://github.com/AdguardTeam/ExtendedCss/issues/6#issuecomment-242328295
 -abp-properties
-! Exluding unsupported uBlock rules
-! ##+js - processed by trust-levels
-! ##script:inject - processed by trust-levels
-$inline-script
-$inline-font
-,inline-script
 ! Excluding redirect instructions
 ! $redirect= - processed by trust-levels
 ! ,redirect= - processed by trust-levels


### PR DESCRIPTION
Related to 
https://github.com/AdguardTeam/CoreLibs/issues/880
https://github.com/AdguardTeam/CoreLibs/issues/1697
https://github.com/AdguardTeam/FiltersRegistry/issues/688