### PR TITLE
Revert "temporary exclusion of bad List-KR rule"

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -26,10 +26,6 @@ $popup,~third-party
 !
 /adguard.
 !
-! temporary exclusion of bad List-KR rule
-! https://github.com/AdguardTeam/AdguardBrowserExtension/issues/2240
-/^http(s|):\/\/([a-z0-9-\.]+|)+[a-z0-9-]+\.[a-z]+\/adManager\/(css|js)\/[A-z]+\.(css|js)$/
-!
 !##################################################
 !
 !*** Add new exlusions as:


### PR DESCRIPTION
Reverts AdguardTeam/FiltersRegistry#694
Bad rule was changed in the filter.