### PR TITLE
Removed excluding cosmetic rules with modifiers from iOS and Safari

### DIFF
--- a/custom_platforms.js
+++ b/custom_platforms.js
@@ -1,11 +1,5 @@
 // Changes in the platforms configuration:
 //
-// Temporary excluding cosmetic rules with modifiers from iOS and Safari:
-// https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#non-basic-rules-modifiers
-// The regular expression that does it is: "^\\[.+?\\].*#(\\$|\\@|\\?|\\@){0,2}#"
-// TODO: should be removed after iOS and Safari versions are updated with
-// SafariConverterLib v2.0.28 or higher.
-//
 // Replacing :has with :-abp-has in all filters.
 // TODO: remove this when ExtCSS v2.0 is released to all AG products.
 
@@ -104,8 +98,7 @@ module.exports = {
                 ",empty",
                 "\\$webrtc",
                 "\\$csp=",
-                "\\$network",
-                "^\\[.+?\\].*#(\\$|\\@|\\?|\\@){0,2}#"
+                "\\$network"
             ],
             "replacements": [
                 {
@@ -203,8 +196,7 @@ module.exports = {
                 ",redirect-rule=",
                 "\\$empty",
                 ",empty",
-                "\\$webrtc",
-                "^\\[.+?\\].*#(\\$|\\@|\\?|\\@){0,2}#"
+                "\\$webrtc"
             ],
             "replacements": [
                 {
@@ -322,8 +314,7 @@ module.exports = {
                 "\\$redirect=",
                 ",redirect=",
                 "\\$redirect-rule=",
-                ",redirect-rule=",
-                "^\\[.+?\\].*#(\\$|\\@|\\?|\\@){0,2}#"
+                ",redirect-rule="
             ],
             "ignoreRuleHints": false
         },


### PR DESCRIPTION
[FiltersCompiler/issues/152](https://github.com/AdguardTeam/FiltersCompiler/issues/152)