### PR TITLE
update compiler to v1.1.69

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AdGuard filters registry",
   "homepage": "http://adguard.com",
   "dependencies": {
-    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.68"
+    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.69"
   },
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,21 +12,21 @@
   resolved "https://registry.yarnpkg.com/@adguard/extended-css/-/extended-css-2.0.26.tgz#f41a32b542fca3bc43240f8fba5b839c9e4c61ae"
   integrity sha512-bc7MWURvdBQchOSc4ZFZis1yhwVTWHH+RAORQ6ljNMJXhf1BFpe98vdPiUn3fuKMmlKtwApZIdUCNww0HsaH+w==
 
-"@adguard/scriptlets@^1.7.13":
-  version "1.7.13"
-  resolved "https://registry.yarnpkg.com/@adguard/scriptlets/-/scriptlets-1.7.13.tgz#9f45d15c9c2944c95844e7857188244757a26733"
-  integrity sha512-kV23/RUQInWnuzK2cfT6RppbGDrJABGpPta3N6/uhjnFhqUlx7vLU9LKi/AD9xFsclyqlXLn3qG9bY65LtBSvw==
+"@adguard/scriptlets@^1.7.14":
+  version "1.7.14"
+  resolved "https://registry.yarnpkg.com/@adguard/scriptlets/-/scriptlets-1.7.14.tgz#3623c7d4b779b0038400b99ae9abe342ac8ec725"
+  integrity sha512-cI3f2Yjg1KSVl7uWdu2IPe8uS4ljDsVxypaZ0nWHlL2wvTndSPuvR+KMb0CnmcknP+83fu/Si3I257i+VMz1sw==
   dependencies:
     "@babel/runtime" "^7.7.2"
     js-yaml "^3.13.1"
 
-"@adguard/tsurlfilter@^1.0.63":
-  version "1.0.63"
-  resolved "https://registry.yarnpkg.com/@adguard/tsurlfilter/-/tsurlfilter-1.0.63.tgz#e755ed09bb120eb6da672098a3d530894c39adb2"
-  integrity sha512-jO2p+CAOhvWBJFRoS+30SjJUc76/PG9GzloHTWBvhzcqGnG6UO1xpobWpV/DaSdxsM3Ay6kmGTxlA7NBAycMuQ==
+"@adguard/tsurlfilter@^1.0.64":
+  version "1.0.64"
+  resolved "https://registry.yarnpkg.com/@adguard/tsurlfilter/-/tsurlfilter-1.0.64.tgz#aa2cae6bc45ccb63849ae99b4056d5d86d437df9"
+  integrity sha512-J32BkXFoi0RNYtFlPdz1fK7Y3FGO5Bmk4D0oEX0YEL05gJVTtvytT7duwFXBLD2GJ+PjQh0u0h96tCPqnE5HnQ==
   dependencies:
     "@adguard/extended-css" "^2.0.26"
-    "@adguard/scriptlets" "^1.7.13"
+    "@adguard/scriptlets" "^1.7.14"
     ip6addr "^0.2.3"
     is-cidr "^4.0.2"
     is-ip "^3.1.0"
@@ -72,13 +72,13 @@ acorn@^8.1.0, acorn@^8.8.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
 
-"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.68":
-  version "1.1.68"
-  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#b4690d084c8a479a3adb3cda428ef5bbad8830e4"
+"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.69":
+  version "1.1.69"
+  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#78fde2caf3f6f937a7ce451dc650709d4e1ad58c"
   dependencies:
     "@adguard/extended-css" "^2.0.24"
-    "@adguard/scriptlets" "^1.7.13"
-    "@adguard/tsurlfilter" "^1.0.63"
+    "@adguard/scriptlets" "^1.7.14"
+    "@adguard/tsurlfilter" "^1.0.64"
     ajv "^8.11.0"
     child_process ">=1.0.2"
     filters-downloader "git+https://github.com/AdguardTeam/FiltersDownloader.git#v1.1.12"


### PR DESCRIPTION
fixed `set-constant` ADG→UBO conversion for `emptyObj` and `emptyArr`