### PR TITLE
Replacing my lists' subscription URLs due to raw.githubusercontent.com problems

### DIFF
--- a/filters/ThirdParty/filter_249_NorwegianList/metadata.json
+++ b/filters/ThirdParty/filter_249_NorwegianList/metadata.json
@@ -7,7 +7,7 @@
   "expires": "4 days",
   "displayNumber": 249,
   "groupId": 7,
-  "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/NorwegianExperimentalList%20alternate%20versions/NordicFiltersAdGuard.txt",
+  "subscriptionUrl": "https://cdn.jsdelivr.net/gh/DandelionSprout/adfilt@master/NorwegianExperimentalList%20alternate%20versions/NordicFiltersAdGuard.txt",
   "tags": [
     "recommended",
     "purpose:ads",

--- a/filters/ThirdParty/filter_250_DandelionSproutAnnoyances/metadata.json
+++ b/filters/ThirdParty/filter_250_DandelionSproutAnnoyances/metadata.json
@@ -7,7 +7,7 @@
   "expires": "4 days",
   "displayNumber": 100,
   "groupId": 4,
-  "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/AnnoyancesList",
+  "subscriptionUrl": "https://gitlab.com/DandelionSprout/adfilt/-/raw/master/AnnoyancesList",
   "tags": [
     "purpose:annoyances",
     "reference:2"

--- a/filters/ThirdParty/filter_251_LegitimateURLShortener/metadata.json
+++ b/filters/ThirdParty/filter_251_LegitimateURLShortener/metadata.json
@@ -7,7 +7,7 @@
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 2,
-  "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/LegitimateURLShortener.txt",
+  "subscriptionUrl": "https://cdn.jsdelivr.net/gh/DandelionSprout/adfilt@master/LegitimateURLShortener.txt",
   "tags": [
     "purpose:privacy"
   ],

--- a/filters/ThirdParty/filter_252_DandelionSproutSerboCroatian/metadata.json
+++ b/filters/ThirdParty/filter_252_DandelionSproutSerboCroatian/metadata.json
@@ -7,7 +7,7 @@
   "expires": "4 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "https://raw.githubusercontent.com/DandelionSprout/adfilt/master/SerboCroatianList.txt",
+  "subscriptionUrl": "https://cdn.jsdelivr.net/gh/DandelionSprout/adfilt@master/SerboCroatianList.txt",
   "tags": [
     "purpose:ads",
     "lang:sr",


### PR DESCRIPTION
For unknown reasons (I've received no info from GitHub about it), the sync time between my list edits and the time they show up on `raw.githubusercontent.com`, has recently increased from 5~9min, to somewhere more than 4 *hours*, whereas CDN services and GitLab CI/CD mirroring takes much less than 4 hours before listfixes go live.

It was a 50:50 call whether to use JSDelivr or GitLab, with neither site's ping limits being likely to be affected by Filters Registry's fetching of lists from them; I went with JSDelivr for 3 of them. For *Annoyances List* I used GitLab due to JSDelivr having possible incompatibilites regarding non-suffix files.