### PR TITLE
exclude ##.adsbygoogle

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -36,10 +36,10 @@ $popup,~third-party
 !
 !### Anti-adblock baits ###
 ! all filters
-/^##\.adsbygoogle$/
-/###banner_ad$/
-/^##\.adsbox$/
-/^##\.afs_ads$/
+/^(~.*)?##\.adsbygoogle$/
+/^(~.*)?###banner_ad$/
+/^(~.*)?##\.adsbox$/
+/^(~.*)?##\.afs_ads$/
 !
 !### Easylist ###
 !

--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -36,6 +36,7 @@ $popup,~third-party
 !
 !### Anti-adblock baits ###
 ! all filters
+/^##\.adsbygoogle$/
 /###banner_ad$/
 /^##\.adsbox$/
 /^##\.afs_ads$/


### PR DESCRIPTION
For https://github.com/easylist/easylist/commit/c09ae084dc666529d0ae0e639836f423bd1231ff

BTW isn't `^` needed for `/###banner_ad$/` as well? Specific `###banner_ad` may be used by good reason.