### PR TITLE
New and old inclusions for `AdGuard Russian`

### DIFF
--- a/filters/filter_1_Russian/template.txt
+++ b/filters/filter_1_Russian/template.txt
@@ -6,43 +6,47 @@
 !-------------------------------------------------------------------------------!
 @include ../general_js_api.txt
 !-------------------------------------------------------------------------------!
+!-------------------------------------------------------------------------------!
+!------------------ Common advertising networks --------------------------------!
+!-------------------------------------------------------------------------------!
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/common-sections/adservers.txt"
+!-------------------------------------------------------------------------------!
+!------------------ Common banner names ----------------------------------------!
+!-------------------------------------------------------------------------------!
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/common-sections/general_url.txt"
+!-------------------------------------------------------------------------------!
+!------------------ Common general hiding rules---------------------------------!
+!-------------------------------------------------------------------------------!
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/common-sections/general_elemhide.txt"
+!
+!-------------------------------------------------------------------------------!
 !------------------ Advertising networks ---------------------------------------!
 !-------------------------------------------------------------------------------!
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/adservers.txt"
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/adservers_firstparty.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/adservers_firstparty.txt"
 !-------------------------------------------------------------------------------!
-!------------------ Common anti-adblock ----------------------------------------!
+!------------------ Anti-adblock rules -----------------------------------------!
 !-------------------------------------------------------------------------------!
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/antiadblock.txt"
-!-------------------------------------------------------------------------------!
-!------------------ Extended CSS rules -----------------------------------------!
-!-------------------------------------------------------------------------------!
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/css_extended.txt"
-!-------------------------------------------------------------------------------!
-!------------------ General hiding rules----------------------------------------!
-!-------------------------------------------------------------------------------!
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/general_elemhide.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/antiadblock.txt"
 !-------------------------------------------------------------------------------!
 !------------------ General javascript, CSS and HTML extensions ----------------!
 !-------------------------------------------------------------------------------!
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/general_extensions.txt"
-!-------------------------------------------------------------------------------!
-!------------------ Banner names -----------------------------------------------!
-!-------------------------------------------------------------------------------!
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/general_url.txt"
-!-------------------------------------------------------------------------------!
-!------------------ News exchange ----------------------------------------------!
-!-------------------------------------------------------------------------------!
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/news_exchange.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/general_extensions.txt"
 !-------------------------------------------------------------------------------!
 !------------------ Rules for specific web sites  ------------------------------!
 !-------------------------------------------------------------------------------!
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/specific.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/specific.txt"
 !-------------------------------------------------------------------------------!
 !------------------ Content replacement rules ----------------------------------!
 !-------------------------------------------------------------------------------!
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/replace.txt"
+!-------------------------------------------------------------------------------!
+! Old inslusions
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/adservers.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/adservers_firstparty.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/antiadblock.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/general_elemhide.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/general_extensions.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/general_url.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/specific.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/replace.txt"
-!-------------------------------------------------------------------------------!
-!-------------- Fixing filtration errors (false-positive) ----------------------!
-!-------------------------------------------------------------------------------!
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/allowlist.txt"

--- a/filters/filter_1_Russian/template.txt
+++ b/filters/filter_1_Russian/template.txt
@@ -49,6 +49,7 @@
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/common-sections/allowlist.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/allowlist.txt"
 !-------------------------------------------------------------------------------!
+! TODO: remove inclusions below after moving the rules to the new files
 ! Old inсlusions
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/adservers.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/adservers_firstparty.txt"

--- a/filters/filter_1_Russian/template.txt
+++ b/filters/filter_1_Russian/template.txt
@@ -40,7 +40,7 @@
 !-------------------------------------------------------------------------------!
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/replace.txt"
 !-------------------------------------------------------------------------------!
-! Old inslusions
+! Old inсlusions
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/adservers.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/adservers_firstparty.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/antiadblock.txt"

--- a/filters/filter_1_Russian/template.txt
+++ b/filters/filter_1_Russian/template.txt
@@ -22,23 +22,32 @@
 !-------------------------------------------------------------------------------!
 !------------------ Advertising networks ---------------------------------------!
 !-------------------------------------------------------------------------------!
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/common-sections/adservers_firstparty.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/adservers_firstparty.txt"
 !-------------------------------------------------------------------------------!
 !------------------ Anti-adblock rules -----------------------------------------!
 !-------------------------------------------------------------------------------!
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/common-sections/antiadblock.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/antiadblock.txt"
 !-------------------------------------------------------------------------------!
 !------------------ General javascript, CSS and HTML extensions ----------------!
 !-------------------------------------------------------------------------------!
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/common-sections/general_extensions.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/general_extensions.txt"
 !-------------------------------------------------------------------------------!
 !------------------ Rules for specific web sites  ------------------------------!
 !-------------------------------------------------------------------------------!
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/common-sections/specific.txt"
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/specific.txt"
 !-------------------------------------------------------------------------------!
 !------------------ Content replacement rules ----------------------------------!
 !-------------------------------------------------------------------------------!
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/replace.txt"
+!-------------------------------------------------------------------------------!
+!-------------- Fixing filtration errors (false-positive) ----------------------!
+!-------------------------------------------------------------------------------!
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/common-sections/allowlist.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/CyrillicFilters/RussianFilter/sections/allowlist.txt"
 !-------------------------------------------------------------------------------!
 ! Old inсlusions
 @include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/RussianFilter/sections/adservers.txt"


### PR DESCRIPTION
Related to https://github.com/AdguardTeam/FiltersRegistry/issues/735.
`news_exchange.txt` and `css_extended.txt` were removed. Now they are in `adservers.txt` and `specific.txt`.
`Old inclusions` will be removed after merging https://github.com/AdguardTeam/FiltersRegistry/pull/741.