### PR TITLE
Remove some unsupported modifiers for iOS, Safari

### DIFF
--- a/custom_platforms.js
+++ b/custom_platforms.js
@@ -87,7 +87,10 @@ module.exports = {
             "removeRulePatterns": [
                 "\\$extension",
                 ",extension",
-                "\\$(.*,)?remove(param|header)",
+                "$removeparam",
+                ",removeparam",
+                "$removeheader",
+                ",removeheader",
                 "^((?!#%#).)*\\$\\$|\\$\\@\\$",
                 "\\$(.*,)?mp4",
                 "\\$(.*,)?replace=",
@@ -185,7 +188,10 @@ module.exports = {
         "path": "extension/safari",
         "configuration": {
             "removeRulePatterns": [
-                "\\$(.*,)?remove(param|header)",
+                "$removeparam",
+                ",removeparam",
+                "$removeheader",
+                ",removeheader",
                 "^((?!#%#).)*\\$\\$|\\$\\@\\$",
                 "\\$(.*,)?mp4",
                 "\\$(.*,)?replace=",

--- a/custom_platforms.js
+++ b/custom_platforms.js
@@ -85,6 +85,9 @@ module.exports = {
         "path": "ios",
         "configuration": {
             "removeRulePatterns": [
+                "\\$extension",
+                ",extension",
+                "\\$remove(param|header)",
                 "^((?!#%#).)*\\$\\$|\\$\\@\\$",
                 "\\$(.*,)?mp4",
                 "\\$(.*,)?replace=",
@@ -103,7 +106,7 @@ module.exports = {
                 "\\$empty",
                 ",empty",
                 "\\$webrtc",
-                "\\$csp=",
+                "\\$csp",
                 "\\$network",
                 "^\\[.+?\\].*#(\\$|\\@|\\?|\\@){0,2}#"
             ],
@@ -182,6 +185,7 @@ module.exports = {
         "path": "extension/safari",
         "configuration": {
             "removeRulePatterns": [
+                "\\$remove(param|header)",
                 "^((?!#%#).)*\\$\\$|\\$\\@\\$",
                 "\\$(.*,)?mp4",
                 "\\$(.*,)?replace=",

--- a/custom_platforms.js
+++ b/custom_platforms.js
@@ -87,9 +87,9 @@ module.exports = {
             "removeRulePatterns": [
                 "\\$extension",
                 ",extension",
-                "$removeparam",
+                "\\$removeparam",
                 ",removeparam",
-                "$removeheader",
+                "\\$removeheader",
                 ",removeheader",
                 "^((?!#%#).)*\\$\\$|\\$\\@\\$",
                 "\\$(.*,)?mp4",
@@ -188,9 +188,9 @@ module.exports = {
         "path": "extension/safari",
         "configuration": {
             "removeRulePatterns": [
-                "$removeparam",
+                "\\$removeparam",
                 ",removeparam",
-                "$removeheader",
+                "\\$removeheader",
                 ",removeheader",
                 "^((?!#%#).)*\\$\\$|\\$\\@\\$",
                 "\\$(.*,)?mp4",

--- a/custom_platforms.js
+++ b/custom_platforms.js
@@ -87,7 +87,7 @@ module.exports = {
             "removeRulePatterns": [
                 "\\$extension",
                 ",extension",
-                "\\$remove(param|header)",
+                "(\\$|,)remove(param|header)",
                 "^((?!#%#).)*\\$\\$|\\$\\@\\$",
                 "\\$(.*,)?mp4",
                 "\\$(.*,)?replace=",
@@ -185,7 +185,7 @@ module.exports = {
         "path": "extension/safari",
         "configuration": {
             "removeRulePatterns": [
-                "\\$remove(param|header)",
+                "(\\$|,)remove(param|header)",
                 "^((?!#%#).)*\\$\\$|\\$\\@\\$",
                 "\\$(.*,)?mp4",
                 "\\$(.*,)?replace=",

--- a/custom_platforms.js
+++ b/custom_platforms.js
@@ -87,7 +87,7 @@ module.exports = {
             "removeRulePatterns": [
                 "\\$extension",
                 ",extension",
-                "(\\$|,)remove(param|header)",
+                "\\$(.*,)?remove(param|header)",
                 "^((?!#%#).)*\\$\\$|\\$\\@\\$",
                 "\\$(.*,)?mp4",
                 "\\$(.*,)?replace=",
@@ -185,7 +185,7 @@ module.exports = {
         "path": "extension/safari",
         "configuration": {
             "removeRulePatterns": [
-                "(\\$|,)remove(param|header)",
+                "\\$(.*,)?remove(param|header)",
                 "^((?!#%#).)*\\$\\$|\\$\\@\\$",
                 "\\$(.*,)?mp4",
                 "\\$(.*,)?replace=",


### PR DESCRIPTION
https://github.com/AdguardTeam/FiltersRegistry/issues/756
~~[Regex](https://regex101.com/r/MhdbBh/1)~~ [replaced by simpler ones](https://github.com/AdguardTeam/FiltersRegistry/pull/757#discussion_r1136906671).