### PR TITLE
Update AdBlockID subscriptionUrl

### DIFF
--- a/filters/ThirdParty/filter_120_AdBlockID/template.txt
+++ b/filters/ThirdParty/filter_120_AdBlockID/template.txt
@@ -1,2 +1,2 @@
 !
-@include "https://raw.githubusercontent.com/realodix/AdBlockID/master/output/adblockid.txt" /exclude="../../exclusions.txt"
+@include "https://raw.githubusercontent.com/realodix/AdBlockID/main/dist/adblockid.adfl.txt" /exclude="../../exclusions.txt"


### PR DESCRIPTION
Previously on https://github.com/AdguardTeam/FiltersRegistry/pull/782, I forgot to change the url in the template.txt file