### PR TITLE
Filter drip.com email trackers

### DIFF
--- a/filters/filter_17_TrackParam/filter.txt
+++ b/filters/filter_17_TrackParam/filter.txt
@@ -219,6 +219,8 @@ $removeparam=ebisAdID
 $removeparam=wickedid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/108478
 $removeparam=irgwc
+! https://help.drip.com/hc/en-us/articles/4424695632269-Suppress-s-From-Rendered-Links
+$removeparam=__s,document
 ! Facebook analytics
 $removeparam=fbclid
 !


### PR DESCRIPTION
I noticed in https://privacytests.org/archive/issue55/ that Mullvad Browser, which uses this filter list, does not filter out the `__s` param.

References:
* https://help.drip.com/hc/en-us/articles/4424695632269-Suppress-s-From-Rendered-Links
* https://github.com/brave/brave-browser/issues/8975
* Also found in https://github.com/DandelionSprout/adfilt/commit/0d082a827876116be4e042d47fb4871c42308b19