### PR TITLE
improve ext_ublock removeRulePatterns

### DIFF
--- a/custom_platforms.js
+++ b/custom_platforms.js
@@ -370,7 +370,7 @@ module.exports = {
                 "\\$urlblock",
                 ",urlblock",
                 "\\$content",
-                ",content",
+                ",content(,|$)",
                 "$webrtc",
                 "#\\$#@media "
             ],


### PR DESCRIPTION
`,content` matches domains part of rule:
```
bridalgown.work,contents-group.work,...###ad3
```

https://github.com/AdguardTeam/FiltersCompiler/issues/178