### PR TITLE
Set strict property of EasyList China to false

### DIFF
--- a/optimization_config.json
+++ b/optimization_config.json
@@ -48,6 +48,7 @@
   {
     "filterId": 104,
     "percent": 45,
+    "strict": false,
     "comment": "EasyList China"
   },
   {


### PR DESCRIPTION
Fix an issue that AdGuard filter compiler for 3rd-party filters lists stopped working.