### PR TITLE
update compiler to 1.1.86

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AdGuard filters registry",
   "homepage": "http://adguard.com",
   "dependencies": {
-    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.82"
+    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.86"
   },
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,20 +7,20 @@
   resolved "https://registry.yarnpkg.com/@adguard/extended-css/-/extended-css-2.0.52.tgz#f5e7c3df1796deb96404a1b6441e7a4c729f09ac"
   integrity sha512-T77MnFD/+A3q93MNEq13qPUXPQRBeOUO9LRyqslcaz7jD5qMcikX1nx436u3PXdZXZpa6R0nnwXQ7wwScDmVgw==
 
-"@adguard/scriptlets@^1.9.7":
-  version "1.9.7"
-  resolved "https://registry.yarnpkg.com/@adguard/scriptlets/-/scriptlets-1.9.7.tgz#dff4637122ba07bec79e48eb88cbb02cd0ba7167"
-  integrity sha512-MZZde1vYfKLLAyVIQKEsuQC2Roc07jjjLsyymuUV3vhh9NhMDTgRG+mVWNp2qAg8zDYEHjm18/R7i0Ir1kj/bQ==
+"@adguard/scriptlets@^1.9.37":
+  version "1.9.37"
+  resolved "https://registry.yarnpkg.com/@adguard/scriptlets/-/scriptlets-1.9.37.tgz#0df8df9ed0b637c4e4dbcd26d7add93443aec95a"
+  integrity sha512-FXsUNaL6f+PyMeXosaXD5kZv2QHiI9iGnfkIDh4N4UQWv0fg5413c+rDdK0x4f34pJUNiSKs5Ol+IE0OWnEFGw==
   dependencies:
     "@babel/runtime" "^7.7.2"
     js-yaml "^3.13.1"
 
-"@adguard/tsurlfilter@^2.0.3":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@adguard/tsurlfilter/-/tsurlfilter-2.0.4.tgz#1f8c04554bbdfbb44706772422f12af149850af7"
-  integrity sha512-nWvCIIOkq+XPhoUf+kozY0ajCHfP4RJDnyvqZj5PMaFKV/lhIIRQgLt1Zai65TRqP1DowLgINsyp9NoyTS9DwA==
+"@adguard/tsurlfilter@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@adguard/tsurlfilter/-/tsurlfilter-2.1.2.tgz#9b0d7e22b6aa194b1adf0ff7183d9cef36e92967"
+  integrity sha512-r/QmqtcJ4ZtJOKEcs9p5KhLNeJXO22SsRU0lQg1m36l1BmcL2s6UGha6sx+zVUfNRHzshdU2QHWWYW/qKAXl9g==
   dependencies:
-    "@adguard/scriptlets" "^1.9.7"
+    "@adguard/scriptlets" "^1.9.37"
     commander "9.4.1"
     ip6addr "0.2.3"
     is-cidr "4.0.2"
@@ -71,13 +71,13 @@ acorn@^8.8.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
-"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.82":
-  version "1.1.82"
-  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#8af201bcbe7e253f2bf68a30a6134c348ec40052"
+"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.86":
+  version "1.1.86"
+  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#e7c60529ccb869415382655867fb555049ed0b0d"
   dependencies:
     "@adguard/extended-css" "^2.0.52"
-    "@adguard/scriptlets" "^1.9.7"
-    "@adguard/tsurlfilter" "^2.0.3"
+    "@adguard/scriptlets" "^1.9.37"
+    "@adguard/tsurlfilter" "2.1.2"
     ajv "^8.11.0"
     child_process ">=1.0.2"
     filters-downloader "git+https://github.com/AdguardTeam/FiltersDownloader.git#v1.1.12"


### PR DESCRIPTION
This compiler version includes tsurlfilter 2.1.2 with rule converter fixed: converter wont unescape slashes inside regexp-values of rule modifiers