### PR TITLE
Disabling `ADgk Mobile China list` filter

### DIFF
--- a/filters/ThirdParty/filter_209_ADgkMobileChinalist/metadata.json
+++ b/filters/ThirdParty/filter_209_ADgkMobileChinalist/metadata.json
@@ -1,6 +1,6 @@
 {
   "filterId": 209,
-  "name": "ADgk Mobile China list",
+  "name": "(Obsolete) ADgk Mobile China list",
   "description": "Filter for Chinese mobile sites.",
   "timeAdded": 1658387825722,
   "homepage": "https://github.com/banbendalao/ADgk",
@@ -11,7 +11,9 @@
   "tags": [
     "purpose:ads",
     "lang:zh",
-    "platform:mobile"
+    "platform:mobile",
+    "obsolete"
   ],
-  "trustLevel": "low"
+  "trustLevel": "low",
+  "disabled": true
 }


### PR DESCRIPTION
We decided to disable the filter for the following reasons:
- there are low contribution activity
- the filter break sites
- issues have not been resolved for a long time.