### PR TITLE
update compiler to v1.1.90

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AdGuard filters registry",
   "homepage": "http://adguard.com",
   "dependencies": {
-    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.88"
+    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.90"
   },
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,9 +71,9 @@ acorn@^8.8.2:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
-"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.88":
-  version "1.1.88"
-  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#782c94b6143102be8d1abc168875a404ff816a90"
+"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.90":
+  version "1.1.90"
+  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#d476c484dbeb88b795c7dc6134097533af72b6e7"
   dependencies:
     "@adguard/extended-css" "^2.0.52"
     "@adguard/scriptlets" "^1.9.37"


### PR DESCRIPTION
fixed ADG→UBO conversion — scriptlet rule with `$path` modifier should not be converted into UBO syntax as unsupported

related:
https://github.com/AdguardTeam/FiltersCompiler/pull/182

