### PR TITLE
fler.cz - Remove f_gid from blocked cookies

### DIFF
--- a/filters/filter_3_Spyware/filter.txt
+++ b/filters/filter_3_Spyware/filter.txt
@@ -53666,8 +53666,6 @@ $cookie=ahoy_visitor,domain=instacart.ca|instacart.com
 ||oilprice.com^$cookie=_omappvs
 ! https://github.com/AdguardTeam/AdguardFilters/issues/151964
 ||izi.ua$cookie=statz_unique_id
-! https://github.com/AdguardTeam/AdguardFilters/issues/151731
-||fler.cz^$cookie=f_gid
 ! https://github.com/AdguardTeam/AdguardFilters/issues/151687
 ||breakdownexpress.com^$cookie=NID
 ||breakdownexpress.com^$cookie=DV


### PR DESCRIPTION
The cookie is needed for logging in.