### PR TITLE
Exclude YouTube scriptlet rule in 3rd-party filters

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -236,7 +236,7 @@ _campaign=$popup
 !###########################
 !
 !### xinggsf ###
-/(?<!m\.)(www\.)?youtube\.com(,)?.*#%#\/\/scriptlet\(/
+#%#//scriptlet('ubo-json-prune.js', '[].playerResponse.adPlacements [].playerResponse.playerAds playerResponse.adPlacements playerResponse.playerAds adPlacements playerAds')
 /##\[id\|=ad\]$/
 /##\.adsbygoogle,\.ads$/
 */market-$script


### PR DESCRIPTION
Fix #834