### PR TITLE
Excluded mail trackers for content blockers

### DIFF
--- a/filters/filter_3_Spyware/template.txt
+++ b/filters/filter_3_Spyware/template.txt
@@ -29,7 +29,7 @@
 !-------------------------------------------------------------------------------!
 !-------------- CNAME mail trackers --------------------------------------------!
 !-------------------------------------------------------------------------------!
-!#if (!adguard_app_ios)
+!#if (!adguard_ext_safari || !adguard_app_ios || !adguard_ext_android_cb)
 @include "https://raw.githubusercontent.com/AdguardTeam/cname-trackers/master/data/combined_disguised_mail_trackers_justdomains.txt" /addModifiers="image"
 !#endif
 !-------------------------------------------------------------------------------!


### PR DESCRIPTION
content blockers don't see domains in proxified urls (for example in Gmail)