### PR TITLE
Disable Web Annoyances Ultralist

### DIFF
--- a/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
+++ b/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
@@ -11,5 +11,6 @@
   "tags": [
     "purpose:annoyances"
   ],
-  "trustLevel": "high"
+  "trustLevel": "high",
+  "disabled": true
 }

--- a/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
+++ b/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
@@ -1,6 +1,6 @@
 {
   "filterId": 201,
-  "name": "Web Annoyances Ultralist",
+  "name": "(Obsolete) Web Annoyances Ultralist",
   "description": "Blocks annoying web elements and reclaims lost screen real estate.",
   "timeAdded": 1560248829763,
   "homepage": "https://github.com/yourduskquibbles/webannoyances/",


### PR DESCRIPTION
I think that Web Annoyances Ultralist can be considered as an obsoleted filters list because it causes many incorrect blocking without maintenance and no related commits.
 - https://github.com/yourduskquibbles/webannoyances/issues/516