### PR TITLE
update build duration for List-KR filters list

### DIFF
--- a/scripts/auto_build.sh
+++ b/scripts/auto_build.sh
@@ -8,7 +8,7 @@
 set -x -e
 
 # Define a list of AdGuard filter IDs
-ADGUARD_FILTERS="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,224"
+ADGUARD_FILTERS="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,224,227"
 
 # Default mode is "all"
 MODE="all"


### PR DESCRIPTION
Today and yesterday (KST), administrator of fmkorea.com resumed bypassing the adblocking system.
The recent changes affected only Unicorn Pro adblocker.

However, what AdGuard is not affected cannot be guaranteed.
Therefore, we need to reduce the build duration for List-KR filters list to distribute any updates faster than now.
