### PR TITLE
Improve removeRulePatterns

### DIFF
--- a/scripts/build/custom_platforms.js
+++ b/scripts/build/custom_platforms.js
@@ -89,8 +89,8 @@ const HTML_FILTERING_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,protobuf`,
- *   and rules with `$removeparam` modifier like `$removeparam=protobuf`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,protobuf` and rules with `$removeparam` modifier like `$removeparam=protobuf`
  * - `.*protobuf` — protobuf modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$protobuf` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -108,8 +108,8 @@ const PROTOBUF_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[app="ads"]`,
- *   and rules with `$removeparam` modifier like `$removeparam=app=ads`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,[app="ads"]` and rules with `$removeparam` modifier like `$removeparam=app=ads`
  * - `.*app=` — app= modifier itself
  *
  * @example
@@ -125,8 +125,8 @@ const APP_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,extension`,
- *   and rules with `$removeparam` modifier like `$removeparam=extension`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,extension` and rules with `$removeparam` modifier like `$removeparam=extension`
  * - `.*extension` — extension modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$extension` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -154,8 +154,8 @@ const ONLY_CONTENT_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,content`,
- *    and rules with `$removeparam` modifier like `$removeparam=content`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,content` and rules with `$removeparam` modifier like `$removeparam=content`
  * - `.*content` — content modifier itself
  * - `(,|$)` — end of line or modifiers divider, as `$content` can be followed by other modifiers (`,`).
  *
@@ -172,8 +172,8 @@ const CONTENT_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,jsinject`,
- *   and rules with `$removeparam` modifier like `$removeparam=jsinject`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,jsinject` and rules with `$removeparam` modifier like `$removeparam=jsinject`
  * - `.*jsinject` — jsinject modifier itself
  * - `(,|$)` — end of line or modifiers divider, as `$jsinject` can be followed by other modifiers (`,`).
  *
@@ -190,8 +190,8 @@ const JSINJECT_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,urlblock`,
- *   and rules with `$removeparam` modifier like `$removeparam=urlblock`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,urlblock` and rules with `$removeparam` modifier like `$removeparam=urlblock`
  * - `.*urlblock` — urlblock modifier itself
  * - `(,|$)` — end of line or modifiers divider, as `$urlblock` can be followed by other modifiers (`,`).
  *
@@ -208,8 +208,8 @@ const URLBLOCK_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,referrerpolicy`,
- *   and rules with `$removeparam` modifier like `$removeparam=referrerpolicy`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,referrerpolicy` and rules with `$removeparam` modifier like `$removeparam=referrerpolicy`
  * - `.*referrerpolicy` — referrerpolicy modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$referrerpolicy` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -227,8 +227,8 @@ const REFERRERPOLICY_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[replace="ads"]`,
- *   and rules with `$removeparam` modifier like `$removeparam=replace=ads`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,[replace="ads"]` and rules with `$removeparam` modifier like `$removeparam=replace=ads`
  * - `.*replace` — replace modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$replace` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -306,8 +306,8 @@ const REMOVEPARAM_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[removeheader="ads"]`,
- *   and rules with `$removeparam` modifier like `$removeparam=removeheader`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,[removeheader="ads"]` and rules with `$removeparam` modifier like `$removeparam=removeheader`
  * - `.*removeheader` — removeheader modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$removeheader` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -325,8 +325,8 @@ const REMOVEHEADER_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[stealth="ads"]`,
- *   and rules with `$removeparam` modifier like `$removeparam=stealth`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *  `[$path=...]##.textad,[stealth="ads"]` and rules with `$removeparam` modifier like `$removeparam=stealth`
  * - `.*stealth` — stealth modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$stealth` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -344,8 +344,8 @@ const STEALTH_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,cookie`,
- *   and rules with `$removeparam` modifier like `$removeparam=cookie`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,cookie` and rules with `$removeparam` modifier like `$removeparam=cookie`
  * - `.*cookie` — cookie modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$cookie` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -363,8 +363,8 @@ const COOKIE_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,redirect`
- *   and rules with `$removeparam` modifier like `$removeparam=redirect`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,redirect` and rules with `$removeparam` modifier like `$removeparam=redirect`
  * - `.*redirect` — redirect modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$redirect` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -382,8 +382,8 @@ const REDIRECT_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,redirect-rule`,
- *   and rules with `$removeparam` modifier like `$removeparam=redirect-rule`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like
+ *   `[$path=...]##.textad,redirect-rule` and rules with `$removeparam` modifier like `$removeparam=redirect-rule`
  * - `.*redirect-rule` — redirect-rule modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$redirect-rule` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).

--- a/scripts/build/custom_platforms.js
+++ b/scripts/build/custom_platforms.js
@@ -89,7 +89,8 @@ const HTML_FILTERING_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,protobuf`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,protobuf`,
+ *   and rules with `$removeparam` modifier like `$removeparam=protobuf`
  * - `.*protobuf` — protobuf modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$protobuf` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -98,7 +99,7 @@ const HTML_FILTERING_MODIFIER_PATTERNS = [
  * https://github.com/AdguardTeam/CoreLibs/issues/1778
  */
 const PROTOBUF_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*protobuf(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*protobuf(,|=|$)',
 ];
 
 /**
@@ -107,14 +108,15 @@ const PROTOBUF_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[app="ads"]`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[app="ads"]`,
+ *   and rules with `$removeparam` modifier like `$removeparam=app=ads`
  * - `.*app=` — app= modifier itself
  *
  * @example
  * ```@@||imasdk.googleapis.com^$app=tv.htv.app```
  */
 const APP_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*app=',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*app=',
 ];
 
 /**
@@ -123,7 +125,8 @@ const APP_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,extension`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,extension`,
+ *   and rules with `$removeparam` modifier like `$removeparam=extension`
  * - `.*extension` — extension modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$extension` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -132,7 +135,7 @@ const APP_MODIFIER_PATTERNS = [
  * ```@@||radar.cloudflare.com^$elemhide,extension,content```
  */
 const EXTENSION_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*extension(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*extension(,|=|$)',
 ];
 
 /**
@@ -151,7 +154,8 @@ const ONLY_CONTENT_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,content`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,content`,
+ *    and rules with `$removeparam` modifier like `$removeparam=content`
  * - `.*content` — content modifier itself
  * - `(,|$)` — end of line or modifiers divider, as `$content` can be followed by other modifiers (`,`).
  *
@@ -159,7 +163,7 @@ const ONLY_CONTENT_MODIFIER_PATTERNS = [
  * ```@@||dnsleaktest.com^$content,elemhide,jsinject```
  */
 const CONTENT_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*content(,|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*content(,|$)',
 ];
 
 /**
@@ -168,7 +172,8 @@ const CONTENT_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,jsinject`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,jsinject`,
+ *   and rules with `$removeparam` modifier like `$removeparam=jsinject`
  * - `.*jsinject` — jsinject modifier itself
  * - `(,|$)` — end of line or modifiers divider, as `$jsinject` can be followed by other modifiers (`,`).
  *
@@ -176,7 +181,7 @@ const CONTENT_MODIFIER_PATTERNS = [
  * ```@@://www.atlassian.com^$elemhide,jsinject,extension```
  */
 const JSINJECT_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*jsinject(,|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*jsinject(,|$)',
 ];
 
 /**
@@ -185,7 +190,8 @@ const JSINJECT_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,urlblock`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,urlblock`,
+ *   and rules with `$removeparam` modifier like `$removeparam=urlblock`
  * - `.*urlblock` — urlblock modifier itself
  * - `(,|$)` — end of line or modifiers divider, as `$urlblock` can be followed by other modifiers (`,`).
  *
@@ -193,7 +199,7 @@ const JSINJECT_MODIFIER_PATTERNS = [
  * ```@@||google.com/settings/ads/onweb$urlblock```
  */
 const URLBLOCK_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*urlblock(,|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*urlblock(,|$)',
 ];
 
 /**
@@ -202,7 +208,8 @@ const URLBLOCK_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,referrerpolicy`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,referrerpolicy`,
+ *   and rules with `$removeparam` modifier like `$removeparam=referrerpolicy`
  * - `.*referrerpolicy` — referrerpolicy modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$referrerpolicy` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -211,7 +218,7 @@ const URLBLOCK_MODIFIER_PATTERNS = [
  * ```||yallo.tv^$referrerpolicy=origin```
  */
 const REFERRERPOLICY_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*referrerpolicy(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*referrerpolicy(,|=|$)',
 ];
 
 /**
@@ -220,7 +227,8 @@ const REFERRERPOLICY_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[replace="ads"]`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[replace="ads"]`,
+ *   and rules with `$removeparam` modifier like `$removeparam=replace=ads`
  * - `.*replace` — replace modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$replace` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -229,7 +237,7 @@ const REFERRERPOLICY_MODIFIER_PATTERNS = [
  * ```||pubads.g.doubleclick.net/gampad/live/ads?correlator=$replace=/(<VAST[\s\S]*?>)[\s\S]*<\/VAST>/\$1<\/VAST>/```
  */
 const REPLACE_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*replace(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*replace(,|=|$)',
 ];
 
 /* eslint-disable max-len */
@@ -240,7 +248,8 @@ const REPLACE_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[hls="ads"]`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[hls="ads"]`,
+ *   and rules with `$removeparam` modifier like `$removeparam=hls=ads`
  * - `.*hls` — hls modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$hls` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -249,7 +258,7 @@ const REPLACE_MODIFIER_PATTERNS = [
  * ```||pubads.g.doubleclick.net/ondemand/hls/*.m3u8$hls=/redirector\.googlevideo\.com\/videoplayback[\s\S]*?dclk_video_ads/,domain=10play.com.au```
  */
 const HLS_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*hls(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*hls(,|=|$)',
 ];
 
 /**
@@ -258,7 +267,8 @@ const HLS_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[jsonprune="ads"]`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[jsonprune="ads"]`,
+ *   and rules with `$removeparam` modifier like `$removeparam=jsonprune`
  * - `.*jsonprune` — jsonprune modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$jsonprune` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -267,7 +277,7 @@ const HLS_MODIFIER_PATTERNS = [
  * ```.com/watch?v=$xmlhttprequest,jsonprune=\$..[adPlacements\, adSlots\, playerAds],domain=youtubekids.com|youtube-nocookie.com|youtube.com```
  */
 const JSONPRUNE_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*jsonprune(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*jsonprune(,|=|$)',
 ];
 
 /* eslint-enable max-len */
@@ -296,7 +306,8 @@ const REMOVEPARAM_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[removeheader="ads"]`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[removeheader="ads"]`,
+ *   and rules with `$removeparam` modifier like `$removeparam=removeheader`
  * - `.*removeheader` — removeheader modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$removeheader` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -305,7 +316,7 @@ const REMOVEPARAM_MODIFIER_PATTERNS = [
  * ```||dubznetwork.com^$removeheader=refresh```
  */
 const REMOVEHEADER_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*removeheader(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*removeheader(,|=|$)',
 ];
 
 /**
@@ -314,7 +325,8 @@ const REMOVEHEADER_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[stealth="ads"]`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,[stealth="ads"]`,
+ *   and rules with `$removeparam` modifier like `$removeparam=stealth`
  * - `.*stealth` — stealth modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$stealth` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -323,7 +335,7 @@ const REMOVEHEADER_MODIFIER_PATTERNS = [
  * ```@@.php?play_vid=$subdocument,stealth=referrer,domain=xyflv.cc```
  */
 const STEALTH_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*stealth(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*stealth(,|=|$)',
 ];
 
 /**
@@ -332,7 +344,8 @@ const STEALTH_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,cookie`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,cookie`,
+ *   and rules with `$removeparam` modifier like `$removeparam=cookie`
  * - `.*cookie` — cookie modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$cookie` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -341,7 +354,7 @@ const STEALTH_MODIFIER_PATTERNS = [
  * ```$cookie=_ga```
  */
 const COOKIE_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*cookie(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*cookie(,|=|$)',
 ];
 
 /**
@@ -350,7 +363,8 @@ const COOKIE_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,redirect`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,redirect`
+ *   and rules with `$removeparam` modifier like `$removeparam=redirect`
  * - `.*redirect` — redirect modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$redirect` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -359,7 +373,7 @@ const COOKIE_MODIFIER_PATTERNS = [
  * ```||google-analytics.com/analytics.js$script,redirect=google-analytics,domain=~olx.*|~banki.ru|~bigc.co.th```
  */
 const REDIRECT_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*redirect(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*redirect(,|=|$)',
 ];
 
 /**
@@ -368,7 +382,8 @@ const REDIRECT_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,redirect-rule`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,redirect-rule`,
+ *   and rules with `$removeparam` modifier like `$removeparam=redirect-rule`
  * - `.*redirect-rule` — redirect-rule modifier itself
  * - `(,|=|$)` — end of line or modifiers divider, as `$redirect-rule` can be followed by other modifiers (`,`),
  *   it may have a value (`=`), or it may be the last modifier in the rule (`$`).
@@ -377,7 +392,7 @@ const REDIRECT_MODIFIER_PATTERNS = [
  * ```$script,third-party,redirect-rule=noopjs,domain=paraphraser.io```
  */
 const REDIRECT_RULE_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*redirect-rule(,|=|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*redirect-rule(,|=|$)',
 ];
 
 /**
@@ -386,7 +401,8 @@ const REDIRECT_RULE_MODIFIER_PATTERNS = [
  *
  * Pattern parts:
  * - `\\$` — modifiers divider
- * - `(?!((path|domain)=.*])).*` — negative lookahead to exclude rules like `[$path=...]##.textad,empty`
+ * - `(?!((path|domain)=.*])|.*removeparam=).*` — negative lookahead to exclude rules like `[$path=...]##.textad,empty`
+ *   and rules with `$removeparam` modifier like `$removeparam=empty`
  * - `.*empty` — empty modifier itself
  * - `(,|$)` — end of line or modifiers divider, as `$empty` can be followed by other modifiers (`,`).
  *
@@ -394,7 +410,7 @@ const REDIRECT_RULE_MODIFIER_PATTERNS = [
  * ```Deprecated, use $redirect=nooptext instead```
  */
 const EMPTY_MODIFIER_PATTERNS = [
-    '\\$(?!((path|domain)=.*])).*empty(,|$)',
+    '\\$(?!((path|domain)=.*])|.*removeparam=).*empty(,|$)',
 ];
 
 /**


### PR DESCRIPTION
Do not remove `$removeparam` modifier if its value contains part of other modifiers.
Related to - https://github.com/AdguardTeam/AdguardFilters/issues/170206#issuecomment-1883912624