### PR TITLE
AG-29197: increase expires date for extension filters to 10 days (except safari)

### DIFF
--- a/scripts/build/custom_platforms.js
+++ b/scripts/build/custom_platforms.js
@@ -588,6 +588,7 @@ module.exports = {
     'EXTENSION_CHROMIUM': {
         'platform': 'ext_chromium',
         'path': 'extension/chromium',
+        'expires': '10 days',
         'configuration': {
             'removeRulePatterns': CHROMIUM_BASED_EXTENSION_PATTERNS,
             'replacements': null,
@@ -601,6 +602,7 @@ module.exports = {
     'EXTENSION_EDGE': {
         'platform': 'ext_edge',
         'path': 'extension/edge',
+        'expires': '10 days',
         'configuration': {
             'removeRulePatterns': CHROMIUM_BASED_EXTENSION_PATTERNS,
             'replacements': null,
@@ -615,6 +617,7 @@ module.exports = {
     'EXTENSION_OPERA': {
         'platform': 'ext_opera',
         'path': 'extension/opera',
+        'expires': '10 days',
         'configuration': {
             'removeRulePatterns': CHROMIUM_BASED_EXTENSION_PATTERNS,
             'replacements': null,
@@ -629,6 +632,7 @@ module.exports = {
     'EXTENSION_FIREFOX': {
         'platform': 'ext_ff',
         'path': 'extension/firefox',
+        'expires': '10 days',
         'configuration': {
             'removeRulePatterns': [
                 ...HTML_FILTERING_MODIFIER_PATTERNS,


### PR DESCRIPTION
We are currently releasing AdGuard 4.3.3, in which we have launched support for differential updates. To test the new scheme, we should extend the validity period of the filters for downloading updates through patches.