### PR TITLE
Disabling `Dandelion Sprout's Annoyances List`

### DIFF
--- a/filters/ThirdParty/filter_250_DandelionSproutAnnoyances/metadata.json
+++ b/filters/ThirdParty/filter_250_DandelionSproutAnnoyances/metadata.json
@@ -12,5 +12,6 @@
     "purpose:annoyances",
     "reference:2"
   ],
-  "trustLevel": "high"
+  "trustLevel": "high",
+  "disabled": true
 }


### PR DESCRIPTION
We have to disable the filter as it breaks the build, and the author hasn't responded yet.