### PR TITLE
Added a critical exclusion for EasyPrivacy for Norwegian users

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -150,6 +150,8 @@ biggestplayer.me##.adblock1
 /generate_204$
 ! https://github.com/AdguardTeam/AdguardFilters/issues/112370
 ||znctrack.net^$third-party
+! https://github.com/easylist/easylist/issues/18542
+||medlemskap.fagforbundet.no^
 ! End: EasyPrivacy
 !###################
 !


### PR DESCRIPTION
Based directly on https://github.com/easylist/easylist/issues/18542

Essentially, `medlemskap` means "membership", and `fagforbundet` means something like "The labour union federation". Said federation is significantly large in Norway, making it beyond belief that EasyPrivacy has had that entry for 7 weeks at the time of writing.