### PR TITLE
Excuded problematic domains from cname-trackers lists

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -46,6 +46,31 @@ $popup,~third-party
 ! End: ADgk Mobile China list
 !###################
 !
+!### cname-trackers problems ###
+! https://github.com/AdguardTeam/AdguardFilters/issues/175337
+||mbox.wegmans.com^
+! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1631
+||tms.capitalone.com^
+! https://github.com/AdguardTeam/AdguardFilters/issues/166702
+||omns.americanexpress.com^
+! Used in shopping emails
+||data.digital.costco.ca^
+||data.digital.costco.com^
+! https://github.com/AdguardTeam/AdguardFilters/issues/162672
+||explore.agilent.com^
+! https://github.com/AdguardTeam/AdguardFilters/issues/160473
+||go.oracle.com^
+! https://github.com/hagezi/dns-blocklists/issues/1453
+||data.ubi.com^
+! https://github.com/AdguardTeam/AdguardFilters/issues/159117
+||data-60d896f23d.radio.net^
+! unblock https://form.ict-toshiba.jp/contact_form_recipewizard
+||form.ict-toshiba.jp^
+! cart blocked at www.matsuzaka-steak.com
+||cart.matsuzaka-steak.com^
+! End:
+!###############################
+!
 !### Easylist ###
 !
 ! Causes many problems, especially in Safari

--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -68,7 +68,7 @@ $popup,~third-party
 ||form.ict-toshiba.jp^
 ! cart blocked at www.matsuzaka-steak.com
 ||cart.matsuzaka-steak.com^
-! End:
+! End: cname-trackers problems
 !###############################
 !
 !### Easylist ###

--- a/filters/filter_3_Spyware/template.txt
+++ b/filters/filter_3_Spyware/template.txt
@@ -21,11 +21,7 @@
 !-------------------------------------------------------------------------------!
 !-------------- CNAME trackers  ------------------------------------------------!
 !-------------------------------------------------------------------------------!
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/SpywareFilter/sections/cname_trackers.txt"
-!-------------------------------------------------------------------------------!
-!-------------- CNAME trackers exceptions --------------------------------------!
-!-------------------------------------------------------------------------------!
-@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/SpywareFilter/sections/cname_allowlist.txt"
+@include "https://raw.githubusercontent.com/AdguardTeam/AdguardFilters/master/SpywareFilter/sections/cname_trackers.txt" /exclude="../exclusions.txt"
 !-------------------------------------------------------------------------------!
 !-------------- CNAME mail trackers --------------------------------------------!
 !-------------------------------------------------------------------------------!


### PR DESCRIPTION
* Changed and transferred from https://github.com/AdguardTeam/AdguardFilters/blob/b4c849d8c4f60606510203e9ff860a0df2930ebf/SpywareFilter/sections/cname_allowlist.txt

* Added `/exclude="../exclusions.txt"` to `cname_trackers` include of AdGuard Tracking Protection filter.

TODO: remove `SpywareFilter\sections\cname_allowlist.txt` from `AdguardFilters` after merge.