### PR TITLE
Fix medlemskap.fagforbundet.no - incorrect blocking by CNAME

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -47,6 +47,8 @@ $popup,~third-party
 !###################
 !
 !### cname-trackers problems ###
+! https://github.com/AdguardTeam/cname-trackers/issues/96
+||medlemskap.fagforbundet.no^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/175337
 ||mbox.wegmans.com^
 ! https://github.com/AdguardTeam/AdGuardSDNSFilter/issues/1631


### PR DESCRIPTION
https://github.com/AdguardTeam/FiltersRegistry/pull/937#issuecomment-2039738772