### PR TITLE
Fix chzzk.naver.com

### DIFF
--- a/filters/ThirdParty/filter_227_List-KR/trusted-rules.txt
+++ b/filters/ThirdParty/filter_227_List-KR/trusted-rules.txt
@@ -1,5 +1,5 @@
 ! This file contains the trusted rules
-chzzk.naver.com#%#//scriptlet('trusted-replace-xhr-response', ',"adFree":false', ',"adFree":true', 'my-info')
+! chzzk.naver.com#%#//scriptlet('trusted-replace-xhr-response', ',"adFree":false', ',"adFree":true', 'my-info')
 !#if adguard_ext_safari
 compuzone.co.kr#%#AG_onLoad(() => { if (document.querySelector("input[name=SearchProductKey]").value === "") { document.querySelector("input#HeadSearchKeyword").value = ""; document.querySelector("input#fixedSearchKeyword").value = ""; } })();
 !#endif


### PR DESCRIPTION
If you have a permission about managing chatting of a channel at chzzk.naver.com, you cannot see the administrator option after right-click a watcher's nickname.

However, If the trusted scriptlet rule is disabled or removed without any change, a watcher cannot see the PIP button in a live streaming player.
So, I push a temporary patch ( https://github.com/List-KR/List-KR/commit/bf0576fa3399ed8e3063f8c35a4cad990e47d8fc ) for the issue. 

After https://github.com/AdguardTeam/Scriptlets/issues/419 is resolved, it should be rechecked.