### PR TITLE
excluding easylist rule

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -75,6 +75,8 @@ $popup,~third-party
 !
 !### Easylist ###
 !
+! We have ##.ad-unit:not(.textads) in our filters
+/^##\##.ad-unit$/
 ! Causes many problems, especially in Safari
 /^:\/\/adv\.\$popup\,domain=~/
 ! Moved to Tracking Protection filter


### PR DESCRIPTION
We have `##.ad-unit:not(.textads)` in our rules and EasyList's rule is hiding ones with .textads.