### PR TITLE
Fixed 256 Scam Blocklist by DurableNapkin

### DIFF
--- a/filters/ThirdParty/filter_256_Scam_Blocklist/template.txt
+++ b/filters/ThirdParty/filter_256_Scam_Blocklist/template.txt
@@ -1,2 +1,2 @@
 !
-@include "https://raw.githubusercontent.com/durablenapkin/scamblocklist/master/adguard.txt" /exclude="../../exclusions.txt" /addModifiers="all" /notOptimized
+@include "https://raw.githubusercontent.com/durablenapkin/scamblocklist/master/adguard.txt" /exclude="../../exclusions.txt" /notOptimized


### PR DESCRIPTION
Removed `/addModifiers="all"` because author added the necessary modifier, and now rules has 2 modifiers
`||1sttheworld.com^$all$all` - invalid rule