### PR TITLE
Support `ext_chromium_mv3` platform

### DIFF
--- a/filters/ThirdParty/filter_101_EasyList/metadata.json
+++ b/filters/ThirdParty/filter_101_EasyList/metadata.json
@@ -11,5 +11,8 @@
   "tags": [
     "purpose:ads"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_102_ABPindo/metadata.json
+++ b/filters/ThirdParty/filter_102_ABPindo/metadata.json
@@ -13,5 +13,8 @@
     "reference:101",
     "lang:id"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_104_EasyListChina/metadata.json
+++ b/filters/ThirdParty/filter_104_EasyListChina/metadata.json
@@ -13,5 +13,8 @@
     "reference:101",
     "lang:zh"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_106_EasyListDutch/metadata.json
+++ b/filters/ThirdParty/filter_106_EasyListDutch/metadata.json
@@ -13,5 +13,8 @@
     "reference:101",
     "lang:nl"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_107_EasyListGermany/metadata.json
+++ b/filters/ThirdParty/filter_107_EasyListGermany/metadata.json
@@ -13,5 +13,8 @@
     "reference:101",
     "lang:de"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_113_ListeFR/metadata.json
+++ b/filters/ThirdParty/filter_113_ListeFR/metadata.json
@@ -13,5 +13,8 @@
     "reference:101",
     "lang:fr"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_114_ROList/metadata.json
+++ b/filters/ThirdParty/filter_114_ROList/metadata.json
@@ -13,5 +13,8 @@
     "reference:101",
     "lang:ro"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_115_RUAdList/metadata.json
+++ b/filters/ThirdParty/filter_115_RUAdList/metadata.json
@@ -14,6 +14,9 @@
     "reference:101",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_116_Wiltteri/metadata.json
+++ b/filters/ThirdParty/filter_116_Wiltteri/metadata.json
@@ -14,6 +14,9 @@
     "lang:fi",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_117_PolishSubFilters/metadata.json
+++ b/filters/ThirdParty/filter_117_PolishSubFilters/metadata.json
@@ -14,6 +14,9 @@
     "lang:pl",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_118_EasyPrivacy/metadata.json
+++ b/filters/ThirdParty/filter_118_EasyPrivacy/metadata.json
@@ -11,5 +11,8 @@
   "tags": [
     "purpose:privacy"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_119_IcelandicABPList/metadata.json
+++ b/filters/ThirdParty/filter_119_IcelandicABPList/metadata.json
@@ -13,6 +13,9 @@
     "reference:101",
     "lang:is"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_121_VoidGr/metadata.json
+++ b/filters/ThirdParty/filter_121_VoidGr/metadata.json
@@ -13,5 +13,8 @@
     "reference:101",
     "lang:el"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_122_FanboysAnnoyances/metadata.json
+++ b/filters/ThirdParty/filter_122_FanboysAnnoyances/metadata.json
@@ -12,5 +12,8 @@
     "purpose:annoyances",
     "reference:101"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_123_FanboysSocialBlockingList/metadata.json
+++ b/filters/ThirdParty/filter_123_FanboysSocialBlockingList/metadata.json
@@ -12,5 +12,8 @@
     "purpose:social",
     "reference:101"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_124_EasyListPortuguese/metadata.json
+++ b/filters/ThirdParty/filter_124_EasyListPortuguese/metadata.json
@@ -14,5 +14,8 @@
     "lang:es",
     "lang:pt"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_200_ABPJapaneseFilters/metadata.json
+++ b/filters/ThirdParty/filter_200_ABPJapaneseFilters/metadata.json
@@ -15,6 +15,9 @@
     "problematic",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
+++ b/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
@@ -12,6 +12,9 @@
     "purpose:annoyances",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_204_PeterLowesList/metadata.json
+++ b/filters/ThirdParty/filter_204_PeterLowesList/metadata.json
@@ -11,5 +11,8 @@
   "tags": [
     "purpose:privacy"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_205_SchacksAdblockPlusListe/metadata.json
+++ b/filters/ThirdParty/filter_205_SchacksAdblockPlusListe/metadata.json
@@ -13,6 +13,9 @@
     "lang:da",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_206_Xfiles/metadata.json
+++ b/filters/ThirdParty/filter_206_Xfiles/metadata.json
@@ -12,5 +12,8 @@
     "purpose:ads",
     "lang:it"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_207_AdblockWarningRemovalList/metadata.json
+++ b/filters/ThirdParty/filter_207_AdblockWarningRemovalList/metadata.json
@@ -11,5 +11,8 @@
   "tags": [
     "purpose:antiadblock"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_209_ADgkMobileChinalist/metadata.json
+++ b/filters/ThirdParty/filter_209_ADgkMobileChinalist/metadata.json
@@ -14,6 +14,9 @@
     "platform:mobile",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_211_AntiAdblockKillerReek/metadata.json
+++ b/filters/ThirdParty/filter_211_AntiAdblockKillerReek/metadata.json
@@ -12,6 +12,9 @@
     "obsolete",
     "purpose:antiadblock"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_212_RUAdListCounters/metadata.json
+++ b/filters/ThirdParty/filter_212_RUAdListCounters/metadata.json
@@ -12,5 +12,8 @@
     "purpose:privacy",
     "lang:ru"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_213_RUAdListBitBlock/metadata.json
+++ b/filters/ThirdParty/filter_213_RUAdListBitBlock/metadata.json
@@ -14,6 +14,9 @@
     "purpose:social",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_215_FanboysEnancedTrackingList/metadata.json
+++ b/filters/ThirdParty/filter_215_FanboysEnancedTrackingList/metadata.json
@@ -12,6 +12,9 @@
     "purpose:privacy",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_217_PolskiFiltrCookies/metadata.json
+++ b/filters/ThirdParty/filter_217_PolskiFiltrCookies/metadata.json
@@ -12,5 +12,8 @@
     "purpose:cookies",
     "lang:pl"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_219_ChinaListAndEasyList/metadata.json
+++ b/filters/ThirdParty/filter_219_ChinaListAndEasyList/metadata.json
@@ -14,6 +14,9 @@
     "lang:zh",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_220_CJXsAnnoyanceList/metadata.json
+++ b/filters/ThirdParty/filter_220_CJXsAnnoyanceList/metadata.json
@@ -12,5 +12,8 @@
     "purpose:annoyances",
     "lang:zh"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_221_PolskiFiltrSocial/metadata.json
+++ b/filters/ThirdParty/filter_221_PolskiFiltrSocial/metadata.json
@@ -12,5 +12,8 @@
     "purpose:social",
     "lang:pl"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_222_ABPPersian/metadata.json
+++ b/filters/ThirdParty/filter_222_ABPPersian/metadata.json
@@ -13,6 +13,9 @@
     "lang:fa",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_225_fanboyAntifacebook/metadata.json
+++ b/filters/ThirdParty/filter_225_fanboyAntifacebook/metadata.json
@@ -12,5 +12,8 @@
     "purpose:privacy",
     "problematic"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_226_FanboyVietnamese/metadata.json
+++ b/filters/ThirdParty/filter_226_FanboyVietnamese/metadata.json
@@ -13,6 +13,9 @@
     "lang:vi",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_228_xinggsf/metadata.json
+++ b/filters/ThirdParty/filter_228_xinggsf/metadata.json
@@ -12,5 +12,8 @@
     "purpose:ads",
     "lang:zh"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_229_IdontCareAboutCookies/metadata.json
+++ b/filters/ThirdParty/filter_229_IdontCareAboutCookies/metadata.json
@@ -12,6 +12,9 @@
     "purpose:cookies",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_231_EasyListSpanish/metadata.json
+++ b/filters/ThirdParty/filter_231_EasyListSpanish/metadata.json
@@ -13,5 +13,8 @@
     "reference:101",
     "lang:es"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_232_KADPrzekrety/metadata.json
+++ b/filters/ThirdParty/filter_232_KADPrzekrety/metadata.json
@@ -12,5 +12,8 @@
     "purpose:security",
     "lang:pl"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_234_ROList2/metadata.json
+++ b/filters/ThirdParty/filter_234_ROList2/metadata.json
@@ -14,5 +14,8 @@
     "lang:ro",
     "reference:114"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_236_ROad-Block/metadata.json
+++ b/filters/ThirdParty/filter_236_ROad-Block/metadata.json
@@ -12,5 +12,8 @@
     "purpose:ads",
     "lang:ro"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_237_PolishAnnoyance/metadata.json
+++ b/filters/ThirdParty/filter_237_PolishAnnoyance/metadata.json
@@ -12,5 +12,8 @@
     "lang:pl",
     "purpose:annoyances"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_239_FanboyAntifonts/metadata.json
+++ b/filters/ThirdParty/filter_239_FanboyAntifonts/metadata.json
@@ -12,5 +12,8 @@
     "purpose:privacy",
     "problematic"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_240_BarbBlock/metadata.json
+++ b/filters/ThirdParty/filter_240_BarbBlock/metadata.json
@@ -11,6 +11,9 @@
   "tags": [
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_241_FanboyCookiemonster/metadata.json
+++ b/filters/ThirdParty/filter_241_FanboyCookiemonster/metadata.json
@@ -11,5 +11,8 @@
   "tags": [
     "purpose:cookies"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_244_YousList/metadata.json
+++ b/filters/ThirdParty/filter_244_YousList/metadata.json
@@ -12,5 +12,8 @@
     "purpose:ads",
     "lang:ko"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_245_AlleBlock/metadata.json
+++ b/filters/ThirdParty/filter_245_AlleBlock/metadata.json
@@ -13,6 +13,9 @@
     "purpose:annoyances",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low",
   "disabled": true
 }

--- a/filters/ThirdParty/filter_246_EasyListPolish/metadata.json
+++ b/filters/ThirdParty/filter_246_EasyListPolish/metadata.json
@@ -13,5 +13,8 @@
     "reference:101",
     "lang:pl"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "low"
 }

--- a/filters/ThirdParty/filter_247_PolishRssFilters/metadata.json
+++ b/filters/ThirdParty/filter_247_PolishRssFilters/metadata.json
@@ -13,5 +13,8 @@
     "purpose:annoyances",
     "reference:237"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_250_DandelionSproutAnnoyances/metadata.json
+++ b/filters/ThirdParty/filter_250_DandelionSproutAnnoyances/metadata.json
@@ -12,5 +12,8 @@
     "purpose:annoyances",
     "reference:2"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_251_LegitimateURLShortener/metadata.json
+++ b/filters/ThirdParty/filter_251_LegitimateURLShortener/metadata.json
@@ -12,6 +12,7 @@
     "purpose:privacy"
   ],
   "platformsExcluded": [
+    "ext_chromium_mv3",
     "ios",
     "ext_safari",
     "ext_android_cb"

--- a/filters/filter_11_Mobile/metadata.json
+++ b/filters/filter_11_Mobile/metadata.json
@@ -15,8 +15,5 @@
     "reference:2",
     "platform:mobile"
   ],
-  "platformsExcluded": [
-    "ext_chromium_mv3"
-  ],
   "trustLevel": "full"
 }

--- a/filters/filter_11_Mobile/metadata.json
+++ b/filters/filter_11_Mobile/metadata.json
@@ -15,5 +15,8 @@
     "reference:2",
     "platform:mobile"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "full"
 }

--- a/filters/filter_12_Safari/metadata.json
+++ b/filters/filter_12_Safari/metadata.json
@@ -17,6 +17,9 @@
     "platform:ext_android_cb",
     "obsolete"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "full",
   "disabled": true
 }

--- a/filters/filter_14_Annoyances/metadata.json
+++ b/filters/filter_14_Annoyances/metadata.json
@@ -12,5 +12,8 @@
     "purpose:annoyances",
     "reference:2"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "full"
 }

--- a/filters/filter_15_DnsFilter/metadata.json
+++ b/filters/filter_15_DnsFilter/metadata.json
@@ -22,5 +22,8 @@
     "reference:13",
     "reference:16"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "full"
 }

--- a/filters/filter_17_TrackParam/metadata.json
+++ b/filters/filter_17_TrackParam/metadata.json
@@ -12,6 +12,7 @@
     "purpose:privacy"
   ],
   "platformsExcluded": [
+    "ext_chromium_mv3",
     "ios",
     "ext_safari",
     "ext_android_cb"

--- a/filters/filter_17_TrackParam/metadata.json
+++ b/filters/filter_17_TrackParam/metadata.json
@@ -12,7 +12,6 @@
     "purpose:privacy"
   ],
   "platformsExcluded": [
-    "ext_chromium_mv3",
     "ios",
     "ext_safari",
     "ext_android_cb"

--- a/filters/filter_5_Experimental/metadata.json
+++ b/filters/filter_5_Experimental/metadata.json
@@ -11,8 +11,5 @@
   "tags": [
     "problematic"
   ],
-  "platformsExcluded": [
-    "ext_chromium_mv3"
-  ],
   "trustLevel": "full"
 }

--- a/filters/filter_5_Experimental/metadata.json
+++ b/filters/filter_5_Experimental/metadata.json
@@ -11,5 +11,8 @@
   "tags": [
     "problematic"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "full"
 }

--- a/scripts/build/custom_platforms.js
+++ b/scripts/build/custom_platforms.js
@@ -491,7 +491,7 @@ const EXTENDED_CSS_RULES_PATTERNS = [
 ];
 
 /**
- * Used for `EXTENSION_CHROMIUM`, `EXTENSION_EDGE`, and `EXTENSION_OPERA` platforms.
+ * Used for `EXTENSION_CHROMIUM`, `EXTENSION_CHROMIUM_MV3`, `EXTENSION_EDGE`, and `EXTENSION_OPERA` platforms.
  */
 const CHROMIUM_BASED_EXTENSION_PATTERNS = [
     ...HTML_FILTERING_MODIFIER_PATTERNS,
@@ -588,6 +588,20 @@ module.exports = {
     'EXTENSION_CHROMIUM': {
         'platform': 'ext_chromium',
         'path': 'extension/chromium',
+        'expires': '10 days',
+        'configuration': {
+            'removeRulePatterns': CHROMIUM_BASED_EXTENSION_PATTERNS,
+            'replacements': null,
+            'ignoreRuleHints': false,
+        },
+        'defines': {
+            'adguard': true,
+            'adguard_ext_chromium': true,
+        },
+    },
+    'EXTENSION_CHROMIUM_MV3': {
+        'platform': 'ext_chromium_mv3',
+        'path': 'extension/chromium-mv3',
         'expires': '10 days',
         'configuration': {
             'removeRulePatterns': CHROMIUM_BASED_EXTENSION_PATTERNS,


### PR DESCRIPTION
I've added
- `EXTENSION_CHROMIUM_MV3` to `custom_platforms.js` 
- `ext_chromium_mv3` to `platformsExcluded` for multiple filters so for chromium mv3 there will be built:
  - all recommended filters 
  - all security filters (because there is no recommended one in the security group)
  - AdGuard Experimental filter 
  - AdGuard URL Tracking filter