### PR TITLE
Applied the "Already included in" precedence to 1 list

### DIFF
--- a/filters/ThirdParty/filter_251_LegitimateURLShortener/metadata.json
+++ b/filters/ThirdParty/filter_251_LegitimateURLShortener/metadata.json
@@ -1,7 +1,7 @@
 {
   "filterId": 251,
   "name": "Legitimate URL Shortener",
-  "description": "Automatically removes unnecessary '$' and '&' values from URLs, making them easier to copy from the URL bar and pasting elsewhere as links.",
+  "description": "Automatically removes unnecessary '$' and '&' values from URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Already included in Dandelion Sprout's Annoyances List.",
   "timeAdded": 1626086804599,
   "homepage": "https://github.com/DandelionSprout/adfilt",
   "expires": "5 days",

--- a/locales/en/filters.json
+++ b/locales/en/filters.json
@@ -361,7 +361,7 @@
 	},
 	{
 		"filter.251.name": "Legitimate URL Shortener",
-		"filter.251.description": "Automatically removes unnecessary '$' and '&' values from URLs, making them easier to copy from the URL bar and pasting elsewhere as links."
+		"filter.251.description": "Automatically removes unnecessary '$' and '&' values from URLs, making them easier to copy from the URL bar and pasting elsewhere as links. Already included in Dandelion Sprout's Annoyances List."
 	},
 	{
 		"filter.252.name": "Dandelion Sprout's Serbo-Croatian List",


### PR DESCRIPTION
Namely "Legitimate URL Shortener", following the precedence used for the EasyList metadata.