### PR TITLE
Fix youtrannytube.com

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -47,6 +47,8 @@ $popup,~third-party
 !###################
 !
 !### cname-trackers problems ###
+! https://github.com/AdguardTeam/AdguardFilters/issues/185762
+||tubestatic.usco1621-b.com^
 ! https://github.com/AdguardTeam/cname-trackers/issues/96
 ||medlemskap.fagforbundet.no^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/175337


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/185762

 This domain hosts the player
 
`tubestatic.usco1621-b.com/static/ae-player`
