### PR TITLE
mail.163.com #983

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -275,7 +275,7 @@ _campaign=$popup
 /##\.adsbygoogle,\.ads$/
 */market-$script
 ! https://github.com/AdguardTeam/FiltersRegistry/issues/983
-^g\.163\.com$
+/^g\.163\.com$/
 ! https://github.com/AdguardTeam/AdguardFilters/issues/180570
 */js/118.
 ! https://github.com/xinggsf/Adblock-Plus-Rule/issues/23

--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -274,6 +274,8 @@ _campaign=$popup
 /##\[id\|=ad\]$/
 /##\.adsbygoogle,\.ads$/
 */market-$script
+! https://github.com/AdguardTeam/FiltersRegistry/issues/983
+^g\.163\.com$
 ! https://github.com/AdguardTeam/AdguardFilters/issues/180570
 */js/118.
 ! https://github.com/xinggsf/Adblock-Plus-Rule/issues/23


### PR DESCRIPTION
https://github.com/AdguardTeam/FiltersRegistry/issues/983

`g.163.com` blocks too much. For example - `reg.163.com` subdomains.