### PR TITLE
Considering excluding the MV3 extension from 2 of my lists

### DIFF
--- a/filters/ThirdParty/filter_249_NorwegianList/metadata.json
+++ b/filters/ThirdParty/filter_249_NorwegianList/metadata.json
@@ -17,5 +17,8 @@
     "lang:is",
     "lang:fo"
   ],
+  "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }

--- a/filters/ThirdParty/filter_252_DandelionSproutSerboCroatian/metadata.json
+++ b/filters/ThirdParty/filter_252_DandelionSproutSerboCroatian/metadata.json
@@ -14,7 +14,7 @@
     "lang:hr",
     "recommended"
   ],
-    "platformsExcluded": [
+  "platformsExcluded": [
     "ext_chromium_mv3"
   ],
   "trustLevel": "high"

--- a/filters/ThirdParty/filter_252_DandelionSproutSerboCroatian/metadata.json
+++ b/filters/ThirdParty/filter_252_DandelionSproutSerboCroatian/metadata.json
@@ -14,5 +14,8 @@
     "lang:hr",
     "recommended"
   ],
+    "platformsExcluded": [
+    "ext_chromium_mv3"
+  ],
   "trustLevel": "high"
 }


### PR DESCRIPTION
So, well, it's not exactly a secret that I'm hostile to the overall concept of MV3, and have been for around 3 years by now.

So I've gradually and loosely thought about excluding 2 more of my lists from AG's dedicated MV3 extension, presuming people would chip in with their views on it. If the consensus would end up as "It'd be ridiculous to exclude regional lists from the MV3 extension" or similar wordings, then I'd accept such a verdict.