### PR TITLE
Fix mobile filter

### DIFF
--- a/filters/filter_2_Base/filter.txt
+++ b/filters/filter_2_Base/filter.txt
@@ -38520,22 +38520,6 @@ heureka.cz,modhub.us,missyusa.com,cruciverba.it,motscroises.fr,palabr.as,word-gr
 ! Common rules, which partially hide banners
 !#if (adguard_app_ios || adguard_ext_android_cb)
 missyusa.com,issuya.com,pressian.com,pravda.com.ua,lamire.jp,picrew.me,mydaily.co.kr,badmouth1.com,taxguru.in,sportsrec.com,reportera.co.kr,tweaksforgeeks.com,fourfourtwo.co.kr,flatpanelshd.com,wfmz.com,videogamemods.com,dziennik.pl,eurointegration.com.ua,jin115.com,gloria.hr,etnews.com,carscoops.com,sportsseoul.com,onlinegdb.com,text-compare.com,winfuture.de,hoyme.jp,timesofindia.indiatimes.com,blog.esuteru.com,blog.livedoor.jp,itainews.com##a[target="_blank"][rel="noopener noreferrer"]:has(> div#container > div.img_container > img[src^="https://asset.ad-shield.cc"])
-##a[href*="/fl1hrrg/"] > div[id^="jizsl_"] > div[class^="jizsl_"]
-##a[href*="/fl1hrrg/"][style*="width:300px!important"]
-##a[id^="jizsl_"] > amp-img[class^="jizsl_"]
-##body > a[href^="https://www.amazon."][href*="tag=adshield"][target="_blank"]
-##body > a[href^="https://s.click.aliexpress.com"][target="_blank"][rel="noopener noreferrer"]
-##body > div[style="display:inline"] div[id^="jizsl_"]
-##div[class^="jizsl_"] > a[href*="/fl1hrrg/"]
-##div[id^="jizsl_"][ad_feedback_url^="https://uncn.jp"]
-##div[id^="jizsl_"][style$="height:250px;overflow:hidden;"]
-##div[id^="jizsl_"][style*="width:336px;height:280px"]
-##div[id^="jizsl_"][video_id]
-##html[class^="jizsl_"][amp4ads]
-##iframe.aspw[aria-label="Advertisement"]
-##iframe[id^="jizsl_"][name^="adroute_ads_frame_adblock_"]
-##img.aspw
-##img[id^="jizsl_"]
 !#endif
 ! END: Ad-Shield ad reinsertion
 !


### PR DESCRIPTION
There is a problem with dogdrip.net , wfmz, etc on the mobile Adguard. After erasing them one by one and testing them all, all the filters that have been removed have an effect.

```
solve below issues
- https://github.com/AdguardTeam/AdGuardForSafari/issues/1020
- https://github.com/AdguardTeam/AdguardFilters/issues/189115
```