### PR TITLE
Fix #1006 playzone.cz

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -479,6 +479,8 @@ $~object-subrequest
 !#####################
 !
 !### EasyList Czech and Slovak ###
+! https://github.com/AdguardTeam/FiltersRegistry/issues/1006
+||playzone.cz^$csp=child-src *
 ! https://github.com/AdguardTeam/AdguardFilters/issues/174196
 /^(~.*)?##\.r-main$/
 ! End: EasyList Czech and Slovak


### PR DESCRIPTION
https://github.com/AdguardTeam/FiltersRegistry/issues/1006

Excluded instead badfiltering, because of a bug in Mv3 extension - these rules do not work
https://github.com/AdguardTeam/AdguardBrowserExtension/issues/2965

```
@@||playzone.cz^$csp=child-src *
```
or
```
||playzone.cz^$csp=child-src *,badfilter
```