### PR TITLE
add desi TLD

### DIFF
--- a/scripts/wildcard-domain-processor/top-tld.ts
+++ b/scripts/wildcard-domain-processor/top-tld.ts
@@ -71,6 +71,7 @@ export const TOP_LEVEL_DOMAIN_LIST = [
     'com.vn',
     'cz',
     'de',
+    'desi',
     'dev',
     'digital',
     'dk',


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/197014

The right TLD (`.desi`) is not on the list, you can search on the lines:
`interxh.site,xhopen.com,xhspot.com,xhwide5.com`

https://filters.adtidy.org/extension/chromium-mv3/filters/18.txt