### PR TITLE
AG-29276 mark filter 14 and 15 as deprecated

### DIFF
--- a/filters/filter_14_Annoyances/metadata.json
+++ b/filters/filter_14_Annoyances/metadata.json
@@ -4,6 +4,7 @@
   "description": "Blocks irritating elements on web pages including cookie notices, third-party widgets and in-page pop-ups. Contains the following AdGuard filters: Cookie Notices, Popups, Mobile App Banners, Other Annoyances and Widgets.",
   "timeAdded": 1404115015843,
   "homepage": "https://adguard.com/kb/general/ad-filtering/adguard-filters/",
+  "deprecated": true,
   "expires": "5 days",
   "displayNumber": 1,
   "groupId": 4,

--- a/filters/filter_15_DnsFilter/metadata.json
+++ b/filters/filter_15_DnsFilter/metadata.json
@@ -4,6 +4,7 @@
   "description": "Filter composed of several other filters (AdGuard Base filter, Social Media filter, Tracking Protection filter, Mobile Ads filter, EasyList and EasyPrivacy) and simplified specifically to be better compatible with DNS-level ad blocking.",
   "timeAdded": 1404115015843,
   "homepage": "https://adguard.com/kb/general/ad-filtering/adguard-filters/",
+  "deprecated": true,
   "expires": "5 days",
   "displayNumber": 3,
   "groupId": 6,


### PR DESCRIPTION
– 14 — AdGuard Annoyances filter
– 15 — AdGuard DNS filter, related to #800

https://github.com/AdguardTeam/FiltersRegistry#metadata