### PR TITLE
Temporarily disabled `Polish Anti-Annoying Special Supplement`

### DIFF
--- a/filters/ThirdParty/filter_247_PolishRssFilters/metadata.json
+++ b/filters/ThirdParty/filter_247_PolishRssFilters/metadata.json
@@ -3,11 +3,11 @@
   "name": "Polish Anti-Annoying Special Supplement",
   "description": "Filters that block and hide RSS elements and remnants of hidden newsletters combined with social elements on Polish websites.",
   "timeAdded": 1522412113779,
-  "homepage": "https://github.com/PolishFiltersTeam/PolishAntiAnnoyingSpecialSupplement",
+  "homepage": "https://github.com/FiltersHeroes/PolishAntiAnnoyingSpecialSupplement/",
   "expires": "5 days",
   "displayNumber": 2,
   "groupId": 7,
-  "subscriptionUrl": "https://raw.githubusercontent.com/PolishFiltersTeam/PolishAntiAnnoyingSpecialSupplement/master/polish_rss_filters.txt",
+  "subscriptionUrl": "https://raw.githubusercontent.com/FiltersHeroes/PolishAntiAnnoyingSpecialSupplement/master/polish_rss_filters.txt",
   "tags": [
     "lang:pl",
     "purpose:annoyances",
@@ -16,5 +16,6 @@
   "platformsExcluded": [
     "ext_chromium_mv3"
   ],
-  "trustLevel": "high"
+  "trustLevel": "high",
+  "disabled": true
 }

--- a/filters/ThirdParty/filter_247_PolishRssFilters/template.txt
+++ b/filters/ThirdParty/filter_247_PolishRssFilters/template.txt
@@ -1,2 +1,2 @@
 !
-@include "https://raw.githubusercontent.com/PolishFiltersTeam/PolishRSSFilters/master/polish_rss_filters.txt" /exclude="../../exclusions.txt"
+@include "https://raw.githubusercontent.com/FiltersHeroes/PolishAntiAnnoyingSpecialSupplement/master/polish_rss_filters.txt" /exclude="../../exclusions.txt"


### PR DESCRIPTION
It's disabled due to [this](https://github.com/AdguardTeam/FiltersRegistry/actions/runs/13372087005/job/37342755428?pr=1057).
Reported https://github.com/FiltersHeroes/PolishAntiAnnoyingSpecialSupplement/issues/274.