### PR TITLE
update diff-builder to 1.1.0 to use system diff utility for patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@adguard/agtree": "^1.1.8",
     "@adguard/dead-domains-linter": "^1.0.19",
-    "@adguard/diff-builder": "1.0.18",
+    "@adguard/diff-builder": "1.1.0",
     "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.149",
     "crypto-js": "^4.2.0"
   },

--- a/scripts/build/patches.js
+++ b/scripts/build/patches.js
@@ -79,8 +79,13 @@ const main = async () => {
 
             const filename = path.basename(file);
 
+            // Just for optimization, skip files that are not in the format of
+            // "{filterId}[_optimized|_without_easylist].txt"
             if (!/\d+(_optimized|_without_easylist)?\.txt/.test(filename)) {
-                console.log(`Skipped generating patch for: ${file}`);
+                // Skip printing logs for non ".txt" files as redundant.
+                if (fileHasTxtExtension) {
+                    console.log(`Skipped generating patch for: ${file}`);
+                }
 
                 return false;
             }
@@ -97,7 +102,10 @@ const main = async () => {
             const res = fileInFiltersFolder && fileHasTxtExtension && fileNotExcluded && fileIncluded;
 
             if (!res) {
-                console.log(`Skipped generating patch for: ${file}`);
+                // Skip printing logs for non ".txt" files as redundant.
+                if (fileHasTxtExtension) {
+                    console.log(`Skipped generating patch for: ${file}`);
+                }
             }
 
             return res;

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,14 +41,13 @@
     crypto-js "^4.2.0"
     diff "git+https://github.com/105th/jsdiff.git#2be2e7df90e8eebd99f0385c7b1dc16c2f4dcc1a"
 
-"@adguard/diff-builder@1.0.18":
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/@adguard/diff-builder/-/diff-builder-1.0.18.tgz#f5a7f29cf717547adcaf823e4ed654d3d2f958bc"
-  integrity sha512-VTaApBCbRUKpBQ7nyDguaIaahg6lkl/IZos1kjjUHBCPji0fDruzTuYm/GOiDJHsGaPlyL8orLmKjJnvku66FQ==
+"@adguard/diff-builder@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@adguard/diff-builder/-/diff-builder-1.1.0.tgz#7ab1bdb8acb314f403f4b7816bcffd30f7d200e9"
+  integrity sha512-2KGzA6vzbwrTX14gopkztdT/5t/pTyf6tn8VQE2EtWlW8n0/j+HG49+CZ/or0nR3IVQi0SNQgfuKIXfz0ReZxQ==
   dependencies:
     commander "^11.1.0"
     crypto-js "^4.2.0"
-    diff "git+https://github.com/105th/jsdiff.git#2be2e7df90e8eebd99f0385c7b1dc16c2f4dcc1a"
 
 "@adguard/ecss-tree@^1.0.8":
   version "1.0.8"


### PR DESCRIPTION
We released a new `diff-builder`, version `1.1.0`, which now uses the system `diff` tool to help prevent problems with creating large patches.

And skip some redundant logs.