### PR TITLE
Update compiler to v1.1.154

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@adguard/agtree": "^1.1.8",
     "@adguard/dead-domains-linter": "^1.0.19",
     "@adguard/diff-builder": "1.1.0",
-    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.153",
+    "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.154",
     "crypto-js": "^4.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1169,9 +1169,9 @@ acorn@^8.11.0, acorn@^8.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.0.tgz#1627bfa2e058148036133b8d9b51a700663c294c"
   integrity sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==
 
-"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.153":
-  version "1.1.153"
-  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#623e1c303d642c5b028dab0727ee38d0ae4f8118"
+"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.1.154":
+  version "1.1.154"
+  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#5b9c6ed5aadb6c8548bc36540b314f087246ef71"
   dependencies:
     "@adguard/extended-css" "^2.0.56"
     "@adguard/filters-downloader" "^2.2.4"


### PR DESCRIPTION
Related to - https://github.com/AdguardTeam/FiltersCompiler/issues/245

New hint `!+ NOT_VALIDATE` has been added.
Now it should be possible to disable validation for a specific rule.
Example:
```
!+ NOT_VALIDATE
||example.org^$newmodifier
```
It might be useful when new modifier has been added and it's supported by some products but it's not supported by filters compiler yet, or in the case when for some reason a correct rule is incorrectly discarded by filters compiler.