### PR TITLE
lock version of `diff-builder` to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
     "ts-jest": "^29.1.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.2"
+  },
+  "resolutions": {
+    "@adguard/diff-builder": "1.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,16 +32,7 @@
     tldts "^6.1.4"
     yargs "^17.7.2"
 
-"@adguard/diff-builder@1.0.17":
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/@adguard/diff-builder/-/diff-builder-1.0.17.tgz#d7fd5f928d75f8955668ea0f45c51ac4ef8dd03a"
-  integrity sha512-pKM8oUQcl8IrVyJIlqwiAUMX4manZrfe2S/a9Np3VDbnaQFbGTwW1cmQoKffmdFUwk7dEKzQ83ILm1OuOu6kZw==
-  dependencies:
-    commander "^11.1.0"
-    crypto-js "^4.2.0"
-    diff "git+https://github.com/105th/jsdiff.git#2be2e7df90e8eebd99f0385c7b1dc16c2f4dcc1a"
-
-"@adguard/diff-builder@1.1.0":
+"@adguard/diff-builder@1.0.17", "@adguard/diff-builder@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@adguard/diff-builder/-/diff-builder-1.1.0.tgz#7ab1bdb8acb314f403f4b7816bcffd30f7d200e9"
   integrity sha512-2KGzA6vzbwrTX14gopkztdT/5t/pTyf6tn8VQE2EtWlW8n0/j+HG49+CZ/or0nR3IVQi0SNQgfuKIXfz0ReZxQ==
@@ -1824,10 +1815,6 @@ diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
-
-"diff@git+https://github.com/105th/jsdiff.git#2be2e7df90e8eebd99f0385c7b1dc16c2f4dcc1a":
-  version "5.1.1"
-  resolved "git+https://github.com/105th/jsdiff.git#2be2e7df90e8eebd99f0385c7b1dc16c2f4dcc1a"
 
 dir-glob@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Since we are waiting for an update of the filtersCompiler (which uses diff-builder and filters-downloader internally), we need to lock the version of diff-builder explicitly to 1.1.0 until the update is released.