### PR TITLE
Added .dad to wildcard-domain-processor

### DIFF
--- a/scripts/wildcard-domain-processor/top-tld.ts
+++ b/scripts/wildcard-domain-processor/top-tld.ts
@@ -70,6 +70,7 @@ export const TOP_LEVEL_DOMAIN_LIST = [
     'com.uy',
     'com.vn',
     'cz',
+    'dad',
     'de',
     'desi',
     'dev',


### PR DESCRIPTION
https://github.com/AdguardTeam/AdguardFilters/issues/204608
required here - `*` does not cover `.dad` domain