### PR TITLE
Handle syntaxes that uBO's logger consider to be unsupported

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@adguard/agtree": "^1.1.8",
         "@adguard/dead-domains-linter": "^1.0.19",
         "@adguard/diff-builder": "1.1.0",
-        "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.2.6",
+        "adguard-filters-compiler": "git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.2.8",
         "crypto-js": "^4.2.0"
     },
     "devDependencies": {

--- a/scripts/build/custom_platforms.js
+++ b/scripts/build/custom_platforms.js
@@ -533,6 +533,20 @@ const SAFARI_BASED_EXTENSION_PATTERNS = [
     ...JSONPRUNE_MODIFIER_PATTERNS,
 ];
 
+/**
+ * Pattern to detect entries which are not supported in uBlock Origin
+ * among them known to be `:matches-property` and generic style rules
+ *
+ * @example
+ * ```unsplash.com#?#.ripi6 > div:matches-property(/__reactFiber/.return.return.memoizedProps.ad)```
+ * @example
+ * ```##div[class="adsbygoogle"][id="ad-detector"] { display: block !important; }```
+ */
+const UBLOCK_BASED_EXTENSION_PATTERNS = [
+    ':matches-property\\(',
+    '^#.* ?\{ ?[a-z]'
+];
+
 module.exports = {
     'WINDOWS': {
         'platform': 'windows',
@@ -783,6 +797,8 @@ module.exports = {
                 ...REFERRERPOLICY_MODIFIER_PATTERNS,
                 ...JSONPRUNE_MODIFIER_PATTERNS,
                 ...UNBLOCKING_IMPORTANT_RULES_PATTERNS,
+                ...REMOVEHEADER_MODIFIER_PATTERNS,
+                ...UBLOCK_BASED_EXTENSION_PATTERNS,
             ],
             'ignoreRuleHints': false,
             'adbHeader': '![Adblock Plus 2.0]',

--- a/scripts/build/custom_platforms.js
+++ b/scripts/build/custom_platforms.js
@@ -434,8 +434,8 @@ const JAVASCRIPT_RULES_PATTERNS = [
  * ```windowslite.net#$#body { overflow: auto !important; }```
  */
 const CSS_RULES_PATTERNS = [
-    '#%#',
-    '#@%#',
+    '#\\$#',
+    '#@\\$#',
 ];
 
 /**
@@ -533,18 +533,30 @@ const SAFARI_BASED_EXTENSION_PATTERNS = [
     ...JSONPRUNE_MODIFIER_PATTERNS,
 ];
 
+/* eslint-disable max-len */
 /**
- * Pattern to detect entries which are not supported in uBlock Origin
- * among them known to be `:matches-property` and generic style rules
+ * Pattern to detect Extended CSS `:matches-property()` rules
  *
  * @example
  * ```unsplash.com#?#.ripi6 > div:matches-property(/__reactFiber/.return.return.memoizedProps.ad)```
  * @example
- * ```##div[class="adsbygoogle"][id="ad-detector"] { display: block !important; }```
+ * ```androidauthority.com#?#main div[class]:has(> div[class]:matches-property(/__reactFiber/.return.memoizedProps.type=med_rect_atf))```
  */
-const UBLOCK_BASED_EXTENSION_PATTERNS = [
+const CSS_MATCHES_PROPERTY_RULES_PATTERNS = [
     ':matches-property\\(',
-    '^#.* ?\{ ?[a-z]'
+];
+/* eslint-enable max-len */
+
+/**
+ * Pattern to detect generic CSS rules
+ *
+ * @example
+ * ```#$#div[class="adsbygoogle"][id="ad-detector"] { display: block !important; }```
+ * @example
+ * ```#$#.pub_728x90.text-ad.textAd.text_ad.text_ads.text-ads.text-ad-links { display: block !important; }```
+ */
+const CSS_GENERIC_RULES_PATTERNS = [
+    '^#\\$#',
 ];
 
 module.exports = {
@@ -798,7 +810,8 @@ module.exports = {
                 ...JSONPRUNE_MODIFIER_PATTERNS,
                 ...UNBLOCKING_IMPORTANT_RULES_PATTERNS,
                 ...REMOVEHEADER_MODIFIER_PATTERNS,
-                ...UBLOCK_BASED_EXTENSION_PATTERNS,
+                ...CSS_MATCHES_PROPERTY_RULES_PATTERNS, // TODO: remove when this issue is fixed - https://github.com/AdguardTeam/FiltersCompiler/issues/252
+                ...CSS_GENERIC_RULES_PATTERNS,
             ],
             'ignoreRuleHints': false,
             'adbHeader': '![Adblock Plus 2.0]',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1160,9 +1160,9 @@ acorn@^8.11.0, acorn@^8.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.0.tgz#1627bfa2e058148036133b8d9b51a700663c294c"
   integrity sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==
 
-"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.2.6":
-  version "1.2.6"
-  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#aed36e4e6bdbe81949a78ed59785d86cefb97415"
+"adguard-filters-compiler@git+https://github.com/AdguardTeam/FiltersCompiler.git#v1.2.8":
+  version "1.2.8"
+  resolved "git+https://github.com/AdguardTeam/FiltersCompiler.git#b55e911c201aafc15f7594caeedd6e23133829eb"
   dependencies:
     "@adguard/extended-css" "^2.0.56"
     "@adguard/filters-downloader" "^2.2.4"


### PR DESCRIPTION
(Corresponds to https://github.com/AdguardTeam/FiltersCompiler/pull/251; though we all know that I'm not going to make a third corresponding PR on BitBucket for this.)

Syncing AdGuard Base's uBO version in uBO gives these notes in uBO's logger as of uO 1.63.3b9:

![image](https://github.com/user-attachments/assets/fc2f26bf-2cd5-49ac-9da4-25258dfb4fb0)

So I figured, "Okay, I can at least give it a try to handle the `$removeheader`, `:matches-property` and generic style ones".