### PR TITLE
Updated filter titles in multiple filter files

### DIFF
--- a/filters/filter_14_Annoyances/filter.txt
+++ b/filters/filter_14_Annoyances/filter.txt
@@ -1,3 +1,4 @@
+! Title: AdGuard Annoyances filter
 ! Homepage: https://github.com/AdguardTeam/AdGuardFilters
 ! License: https://github.com/AdguardTeam/AdguardFilters/blob/master/LICENSE
 !

--- a/filters/filter_17_TrackParam/filter.txt
+++ b/filters/filter_17_TrackParam/filter.txt
@@ -1,3 +1,4 @@
+! Title: AdGuard URL Tracking filter
 ! Homepage: https://github.com/AdguardTeam/AdGuardFilters
 ! License: https://github.com/AdguardTeam/AdguardFilters/blob/master/LICENSE
 !

--- a/filters/filter_2_Base/filter.txt
+++ b/filters/filter_2_Base/filter.txt
@@ -1,3 +1,4 @@
+! Title: AdGuard Base filter
 ! Homepage: https://github.com/AdguardTeam/AdGuardFilters
 ! License: https://github.com/AdguardTeam/AdguardFilters/blob/master/LICENSE
 !

--- a/filters/filter_3_Spyware/filter.txt
+++ b/filters/filter_3_Spyware/filter.txt
@@ -1,3 +1,4 @@
+! Title: AdGuard Tracking Protection filter
 ! Homepage: https://github.com/AdguardTeam/AdGuardFilters
 ! License: https://github.com/AdguardTeam/AdguardFilters/blob/master/LICENSE
 !


### PR DESCRIPTION
## Summary

Added standardized title headers to improve filter list identification and third-party software compatibility.

## Changes Made

Updated the following filter files by adding a `! Title:` header line at the top of each:

1. **AdGuard Base filter** - `filters/filter_2_Base/filter.txt`
2. **AdGuard Tracking Protection filter**  - `filters/filter_3_Spyware/filter.txt`
3. **AdGuard URL Tracking filter** - `filters/filter_17_TrackParam/filter.txt`
4. **AdGuard Annoyances filter** - `filters/filter_14_Annoyances/filter.txt`

## Implementation Details

- Added `! Title: [Filter Name]` as the first line in each filter file
- Example: `! Title: AdGuard Base filter`
- No existing filter rules were modified or removed
- Changes are purely additive and non-breaking

## Rationale

This enhancement provides several benefits:

- **Improved Identification**: Clear, standardized titles make it easier to identify filter lists at a glance
- **Third-Party Compatibility**: Many external applications and filter management tools rely on title headers to properly categorize and display filter lists
- **Consistency**: Establishes a uniform naming convention across all AdGuard filter files
- **User Experience**: Users can more easily distinguish between different filter lists when managing their configurations

## Impact Assessment

- **Risk Level**: Low - purely cosmetic changes with no functional impact
- **Breaking Changes**: None
- **Compatibility**: Maintains full backward compatibility
- **Performance**: No performance impact on filtering functionality

## Testing

This change should not require extensive testing as it only adds metadata comments. However, please verify that:
- Third-party applications correctly parse the new title headers
- Filter list parsing remains unaffected
- No syntax errors were introduced