### PR TITLE
Fix intel.com

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -50,6 +50,8 @@ $popup,~third-party
 !###################
 !
 !### cname-trackers problems ###
+! https://github.com/AdguardTeam/AdguardFilters/issues/207905
+||dogo.intel.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/194839
 ||data-3cd8fb3825.kicker.de^
 ||data-e69b3d32a9.kicker.de^


### PR DESCRIPTION
Fix https://github.com/AdguardTeam/AdguardFilters/issues/207905 

Fixes problem with downloading files on `intel.com`.

File cannot be downloaded when `dogo.intel.com` is blocked (it comes from https://github.com/AdguardTeam/cname-trackers/blob/master/data/trackers/adobe-experience-cloud-(formerly-omniture).txt).