### PR TITLE
Reintroduce Web Annoyances Ultralist

### DIFF
--- a/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
+++ b/filters/ThirdParty/filter_201_WebAnnoyancesUltralist/metadata.json
@@ -1,20 +1,18 @@
 {
   "filterId": 201,
-  "name": "(Obsolete) Web Annoyances Ultralist",
+  "name": "Web Annoyances Ultralist",
   "description": "Blocks annoying web elements and reclaims lost screen real estate.",
   "timeAdded": 1560248829763,
-  "homepage": "https://github.com/yourduskquibbles/webannoyances/",
+  "homepage": "https://github.com/LanikSJ/webannoyances/",
   "expires": "5 days",
   "displayNumber": 100,
   "groupId": 4,
-  "subscriptionUrl": "https://raw.githubusercontent.com/yourduskquibbles/webannoyances/master/ultralist.txt",
+  "subscriptionUrl": "https://raw.githubusercontent.com/LanikSJ/webannoyances/master/ultralist.txt",
   "tags": [
-    "purpose:annoyances",
-    "obsolete"
+    "purpose:annoyances"
   ],
   "platformsExcluded": [
     "ext_chromium_mv3"
   ],
-  "trustLevel": "high",
-  "disabled": true
+  "trustLevel": "high"
 }


### PR DESCRIPTION
Hi, after the [original Web Annoyances Ultralist](https://github.com/yourduskquibbles/webannoyances) became unmaintained, it got removed in #871.

Two years and 459 commits later, we have a [well-established fork](https://github.com/LanikSJ/webannoyances) with many new commits, fixes, etc, a small but established community and a quick maintainer.

It would be nice to add us back again, so that more people can benefit from the (now bugfixed and updated) list, as well as to increase attention to the fork, so that more people feel like contributing, who might have in the past. 

This PR is adding the updated fork again to the list of maintained third party sources. I have just tried to update the URLs and revert the changes done in #871. If I did anything wrong, I apologise.

I thought just asking with a quick PR is the easiest way; I hope this is not too blunt.

