### PR TITLE
Preventing the use of Optimized versions of Dandelion Sprout's Annoyances List on Android/iOS.

### DIFF
--- a/filters/ThirdParty/filter_250_DandelionSproutAnnoyances/metadata.json
+++ b/filters/ThirdParty/filter_250_DandelionSproutAnnoyances/metadata.json
@@ -13,7 +13,9 @@
     "reference:2"
   ],
   "platformsExcluded": [
-    "ext_chromium_mv3"
+    "ext_chromium_mv3",
+    "ios",
+    "android"
   ],
   "trustLevel": "high"
 }


### PR DESCRIPTION
The logical outcome based on #1147.