### PR TITLE
False Positive: cryptoland.com & bridge.link

### DIFF
--- a/filters/ThirdParty/filter_235_PersianBlocker/filter.txt
+++ b/filters/ThirdParty/filter_235_PersianBlocker/filter.txt
@@ -2920,9 +2920,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/filters/filter_15_DnsFilter/filter.txt
+++ b/filters/filter_15_DnsFilter/filter.txt
@@ -118729,9 +118729,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/android/filters/15.txt
+++ b/platforms/android/filters/15.txt
@@ -118721,9 +118721,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/android/filters/15_optimized.txt
+++ b/platforms/android/filters/15_optimized.txt
@@ -117473,8 +117473,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/android/filters/235.txt
+++ b/platforms/android/filters/235.txt
@@ -2757,9 +2757,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/android/filters/235_optimized.txt
+++ b/platforms/android/filters/235_optimized.txt
@@ -2243,8 +2243,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/cli/filters/15.txt
+++ b/platforms/cli/filters/15.txt
@@ -118719,9 +118719,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/cli/filters/15_optimized.txt
+++ b/platforms/cli/filters/15_optimized.txt
@@ -117471,8 +117471,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/cli/filters/235.txt
+++ b/platforms/cli/filters/235.txt
@@ -2757,9 +2757,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/cli/filters/235_optimized.txt
+++ b/platforms/cli/filters/235_optimized.txt
@@ -2243,8 +2243,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/extension/android-content-blocker/filters/15.txt
+++ b/platforms/extension/android-content-blocker/filters/15.txt
@@ -118713,9 +118713,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/extension/android-content-blocker/filters/15_optimized.txt
+++ b/platforms/extension/android-content-blocker/filters/15_optimized.txt
@@ -117472,8 +117472,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/extension/chromium-mv3/filters/235.txt
+++ b/platforms/extension/chromium-mv3/filters/235.txt
@@ -2748,9 +2748,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/extension/chromium-mv3/filters/235_optimized.txt
+++ b/platforms/extension/chromium-mv3/filters/235_optimized.txt
@@ -2234,8 +2234,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/extension/chromium/filters/15.txt
+++ b/platforms/extension/chromium/filters/15.txt
@@ -118719,9 +118719,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/extension/chromium/filters/15_optimized.txt
+++ b/platforms/extension/chromium/filters/15_optimized.txt
@@ -117471,8 +117471,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/extension/chromium/filters/235.txt
+++ b/platforms/extension/chromium/filters/235.txt
@@ -2749,9 +2749,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/extension/chromium/filters/235_optimized.txt
+++ b/platforms/extension/chromium/filters/235_optimized.txt
@@ -2235,8 +2235,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/extension/edge/filters/15.txt
+++ b/platforms/extension/edge/filters/15.txt
@@ -118719,9 +118719,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/extension/edge/filters/15_optimized.txt
+++ b/platforms/extension/edge/filters/15_optimized.txt
@@ -117471,8 +117471,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/extension/edge/filters/235.txt
+++ b/platforms/extension/edge/filters/235.txt
@@ -2749,9 +2749,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/extension/edge/filters/235_optimized.txt
+++ b/platforms/extension/edge/filters/235_optimized.txt
@@ -2235,8 +2235,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/extension/firefox/filters/15.txt
+++ b/platforms/extension/firefox/filters/15.txt
@@ -118719,9 +118719,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/extension/firefox/filters/15_optimized.txt
+++ b/platforms/extension/firefox/filters/15_optimized.txt
@@ -117471,8 +117471,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/extension/firefox/filters/235.txt
+++ b/platforms/extension/firefox/filters/235.txt
@@ -2749,9 +2749,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/extension/firefox/filters/235_optimized.txt
+++ b/platforms/extension/firefox/filters/235_optimized.txt
@@ -2235,8 +2235,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/extension/opera/filters/15.txt
+++ b/platforms/extension/opera/filters/15.txt
@@ -118719,9 +118719,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/extension/opera/filters/15_optimized.txt
+++ b/platforms/extension/opera/filters/15_optimized.txt
@@ -117471,8 +117471,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/extension/opera/filters/235.txt
+++ b/platforms/extension/opera/filters/235.txt
@@ -2749,9 +2749,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/extension/opera/filters/235_optimized.txt
+++ b/platforms/extension/opera/filters/235_optimized.txt
@@ -2235,8 +2235,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/extension/safari/filters/15.txt
+++ b/platforms/extension/safari/filters/15.txt
@@ -118714,9 +118714,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/extension/safari/filters/15_optimized.txt
+++ b/platforms/extension/safari/filters/15_optimized.txt
@@ -117473,8 +117473,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/extension/safari/filters/235.txt
+++ b/platforms/extension/safari/filters/235.txt
@@ -2676,9 +2676,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/extension/safari/filters/235_optimized.txt
+++ b/platforms/extension/safari/filters/235_optimized.txt
@@ -2167,8 +2167,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/extension/ublock/filters/15.txt
+++ b/platforms/extension/ublock/filters/15.txt
@@ -118719,9 +118719,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/extension/ublock/filters/15_optimized.txt
+++ b/platforms/extension/ublock/filters/15_optimized.txt
@@ -117472,8 +117472,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/extension/ublock/filters/235.txt
+++ b/platforms/extension/ublock/filters/235.txt
@@ -2744,9 +2744,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/extension/ublock/filters/235_optimized.txt
+++ b/platforms/extension/ublock/filters/235_optimized.txt
@@ -2230,8 +2230,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/ios/filters/15.txt
+++ b/platforms/ios/filters/15.txt
@@ -118718,9 +118718,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/ios/filters/15_optimized.txt
+++ b/platforms/ios/filters/15_optimized.txt
@@ -117477,8 +117477,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/ios/filters/235.txt
+++ b/platforms/ios/filters/235.txt
@@ -2676,9 +2676,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/ios/filters/235_optimized.txt
+++ b/platforms/ios/filters/235_optimized.txt
@@ -2167,8 +2167,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/mac/filters/15.txt
+++ b/platforms/mac/filters/15.txt
@@ -118720,9 +118720,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/mac/filters/15_optimized.txt
+++ b/platforms/mac/filters/15_optimized.txt
@@ -117472,8 +117472,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/mac/filters/235.txt
+++ b/platforms/mac/filters/235.txt
@@ -2756,9 +2756,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/mac/filters/235_optimized.txt
+++ b/platforms/mac/filters/235_optimized.txt
@@ -2242,8 +2242,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/mac_v2/filters/15.txt
+++ b/platforms/mac_v2/filters/15.txt
@@ -118721,9 +118721,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/mac_v2/filters/15_optimized.txt
+++ b/platforms/mac_v2/filters/15_optimized.txt
@@ -117473,8 +117473,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/mac_v2/filters/235.txt
+++ b/platforms/mac_v2/filters/235.txt
@@ -2757,9 +2757,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/mac_v2/filters/235_optimized.txt
+++ b/platforms/mac_v2/filters/235_optimized.txt
@@ -2243,8 +2243,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/mac_v3/filters/15.txt
+++ b/platforms/mac_v3/filters/15.txt
@@ -118721,9 +118721,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/mac_v3/filters/15_optimized.txt
+++ b/platforms/mac_v3/filters/15_optimized.txt
@@ -117473,8 +117473,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/mac_v3/filters/235.txt
+++ b/platforms/mac_v3/filters/235.txt
@@ -2757,9 +2757,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/mac_v3/filters/235_optimized.txt
+++ b/platforms/mac_v3/filters/235_optimized.txt
@@ -2243,8 +2243,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all

--- a/platforms/windows/filters/15.txt
+++ b/platforms/windows/filters/15.txt
@@ -118721,9 +118721,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-! # https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^
-||bridge.link^
 ! # https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^
 ||mttcoin.com^

--- a/platforms/windows/filters/15_optimized.txt
+++ b/platforms/windows/filters/15_optimized.txt
@@ -117473,8 +117473,6 @@ analytics-*.aasaam.com
 ||aryana.io^
 ||aryacoin.io^
 ||aryastake.io^
-||cryptoland.com^
-||bridge.link^
 ||mtabdil.com^
 ||mttcoin.com^
 ||unique.finance^

--- a/platforms/windows/filters/235.txt
+++ b/platforms/windows/filters/235.txt
@@ -2757,9 +2757,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-! https://github.com/Webamoozcom/warning-list/discussions/23
-||cryptoland.com^$all
-||bridge.link^$all
 ! https://github.com/Webamoozcom/warning-list/discussions/26
 ||mtabdil.com^$all
 ||mttcoin.com^$all

--- a/platforms/windows/filters/235_optimized.txt
+++ b/platforms/windows/filters/235_optimized.txt
@@ -2243,8 +2243,6 @@ zohur12.ir##.sideads
 ||aryana.io^$all
 ||aryacoin.io^$all
 ||aryastake.io^$all
-||cryptoland.com^$all
-||bridge.link^$all
 ||mtabdil.com^$all
 ||mttcoin.com^$all
 ||unique.finance^$all


### PR DESCRIPTION
### Domain(s)
- cryptoland.com
- bridge.link

### Problem
These domains are incorrectly flagged as scam/malicious, but they are legitimate services.
Current AdGuard filters block them based on outdated or incorrect reports.

### Why it’s a False Positive
Independent media sources have confirmed the legitimacy and cleared previous allegations:
- https://www.iranintl.com/202503298684
- https://www.iranintl.com/en/202503309549

### Expected Behavior
The domains should NOT be blocked by any AdGuard filters, including:
- Social
- Security
- Tracking Protection
- Annoyances

### Additional Notes
These domains were previously marked as scam due to misinformation. This is now publicly corrected.
