### PR TITLE
Update exclusions.txt

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -442,7 +442,6 @@ music.yandex.*#?#+js(set-constant, Object.prototype.showBranding, noopFunc)
 ~yandex.net,yandex.*#?#+js(set-constant, home.export.adb, {})
 !
 ! Filter name: Official Polish filters for AdBlock, uBlock Origin & AdGuard
-~biblio.com,~milionczesci.pl,~dizibox.com,~2dehands.be,~ru,~ua,~www.pudelek.pl,~btdb.eu,~ewybory.eu ##[id^="adv-"]:not(#adv-settings)
 www.dobreprogramy.pl##+js(nano-remove-elements-onready.js, #phContent_avastBadge)
 filmweb.pl##+js(nano-remove-elements-onready.js, #skyBanner)
 $popunder,domain=rabatio.com|alerabat.com|salesandshopping.pl|kodyrabatowe.olx.pl|kod.rabatowy.pl
@@ -452,15 +451,9 @@ ppe.pl##+js(ac, active, #m_hot_1)
 ppe.pl##+js(ac, box_active, #hot_1)
 money.pl##div[class]:if(>div[class]:first-child:has-text(REKLAMA):if-not(>*))
 !
-! Filter name: Polish GDPR-Cookies Filters
-nike.com##body[data-overlay="cookieModalSimple"]:watch-attr(data-overlay):not([data-overlay="true"]) #gen-nav-commerce-header-v2 > div.pre-modal-window:has(> .pre-modal > .pre-modal-view > .pre-cookie-modal-body)
-!
 ! Filter name: road-block light
 science.hotnews.ro###\$\{tile\.name\}_\$\{tile\.id\}"
 !
-! Filter name: Polish Annoyances Filters
-nike.com##body[data-overlay*="Modal" i]:watch-attr(data-overlay):not([data-overlay="true"]) #gen-nav-commerce-header-v2 > div.pre-modal-window:has(> .pre-modal > .pre-modal-view > .unite-container):has-text(/newsletter/i)
-meczyki.pl##+js(gnf)
 !
 ! Filter name: Polish Anti Adblock Filters
 magazyn.wp.pl#@#+js(overlay-buster)


### PR DESCRIPTION
First is disabled by comment; additionally, the space has disappeared and new TLDs and CSS negation have appeared there:

https://github.com/AdguardTeam/FiltersRegistry/blob/f4c27530b267169443350295c3e0acba74346ad7/platforms/extension/android-content-blocker/filters/216.txt#L252

Nike rules in that form no longer work and do not exist on the lists.


The [gf](https://github.com/FiltersHeroes/PolishAnnoyanceFilters/blob/33260f49c1e8718359e42d116168d67c1ab6866b/scriptlets/scriptlets.js#L5-L18) scriptlet rule is no longer needed on meczyki (push without damage to thumbnails blocks `meczyki.pl##+js(set, Notification.requestPermission, falseFunc)` in latest Firefox/Chrome), in comment mode for a long time.