### PR TITLE
fix iqiyi.com  https://github.com/AdguardTeam/AdguardFilters/issues/219897

### DIFF
--- a/filters/exclusions.txt
+++ b/filters/exclusions.txt
@@ -50,6 +50,8 @@ $popup,~third-party
 !###################
 !
 !### cname-trackers problems ###
+!https://github.com/AdguardTeam/AdguardFilters/issues/219897
+||t7z.cupid.iqiyi.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/209795
 ||sstats.bitdefender.com^
 ! https://github.com/AdguardTeam/AdguardFilters/issues/207941


### PR DESCRIPTION

users using browser extensions or exe users using a proxy 
The system will detect that the ad has been blocked.