### PR TITLE
fix(optimization): widen filter 201 minPercent bound from 16 to 12

### DIFF
--- a/optimization_config.json
+++ b/optimization_config.json
@@ -124,7 +124,7 @@
   {
     "filterId": 201,
     "percent": 35,
-    "minPercent": 16,
+    "minPercent": 12,
     "strict": true,
     "comment": "Web Annoyances Ultralist"
   },


### PR DESCRIPTION
Actual optimization result for Web Annoyances Ultralist fell below 16%, causing strict-mode build failures in CI.

> tested with my implementation draft: https://github.com/AdguardTeam/FiltersRegistry/pull/1186#pullrequestreview-4262318022

It works after changing `minPercent` to 12  in the `201` stats file (`temp/optimization_config/filters/201/stats.json`)

And I used the command below for local build:

```bash
yarn build:local --include=201 --no-patches-prepare --strip-generated-meta
```