### PR TITLE
chore: add .editorconfig and VS Code extension recommendation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+
+[*.{js,ts,cjs,mjs,json}]
+indent_style = space
+indent_size = 4
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+
+[*.sh]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .idea
-.vscode
+.vscode/*
+!.vscode/extensions.json
 .eslintcache
 .cursorignore
 node_modules

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["editorconfig.editorconfig"]
+}


### PR DESCRIPTION
> from approved FiltersCompiler PR: if you agree that this proposal is good, I will open the same PR in FiltersRegistry.

I always encountered issues with indentation mismatches and unwanted diffs during editing. The current configuration lacks indentation settings for extensions. Therefore, I suggest adding an [EditorConfig](https://editorconfig.org/).

## Problem

Without `.editorconfig`, editors apply their own defaults, causing:

- Indentation mismatches (tabs vs. spaces, 2 vs. 4 spaces)
- Unwanted diffs from trailing whitespace or missing final newlines

## What changes?

- Adds `.editorconfig` to enforce consistent formatting rules across editors (VS Code, JetBrains, Vim, etc.)
- Adds `.vscode/extensions.json` recommending the EditorConfig extension
- Fixes `.gitignore` so `.vscode/extensions.json` is correctly tracked
