### PR TITLE
Strips `version` and `timeUpdated` fields from filters.json and filters.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ for all supported AdGuard products.
 | `yarn build:patches` | Build incremental patches |
 | `yarn generate-cache` | Generate cached `filter.txt` from templates (`tsx scripts/build/build.js --generate-cache`) |
 | `yarn download-stats` | Download per-filter `stats.json` to `temp/optimization/stats/` |
-| `yarn strip-generated-meta` | Strip generated meta lines from platform filter files |
+| `yarn strip-generated-meta` | Strip meta lines from `.txt` files + `version`/`timeUpdated` from `filters.{json,js}` |
 | `yarn test` | Run unit tests (`vitest run`) |
 | `yarn lint` | Run all linters (code + types + markdown) |
 | `yarn lint:code` | ESLint check (`eslint . --ext .js,.ts`) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,21 @@ General code style guidelines for JavaScript are available via link:
 - All other style rules (indentation, line length, Airbnb conventions, etc.)
   are enforced by `.eslintrc.cjs`. Run `yarn lint` to check.
 
+### Runtime data validation (TypeScript/JavaScript)
+
+Before adding any runtime check, decide whether the data is trusted or external. Data the
+system itself produced — own build artifacts, generated JSON, config files the project owns —
+is trusted: JSON.parse + as cast and move on. If such data is malformed, the code SHOULD fail
+loudly; never silently skip, default, or return-early on an unexpected shape.
+
+Genuinely external input (user input, network responses, third-party files) gets validated
+ONCE at the boundary — with a schema library (zod/valibot) when the project already has one —
+and the parsed type is trusted downstream. Do not re-validate past the boundary.
+
+Never write hand-rolled type guards (`isRecord`, `typeof x === 'object' && x !== null && !Array.isArray(x)` chains).
+A guard justified only by a hypothetical "what if the data is corrupt" is a smell:
+answer whether that corruption is real for THIS data source before writing anything.
+
 ### Testing
 
 - Test framework: Vitest.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ for all supported AdGuard products.
 | `yarn build:patches` | Build incremental patches |
 | `yarn generate-cache` | Generate cached `filter.txt` from templates (`tsx scripts/build/build.js --generate-cache`) |
 | `yarn download-stats` | Download per-filter `stats.json` to `temp/optimization/stats/` |
-| `yarn strip-generated-meta` | Strip meta lines from `.txt` files + `version`/`timeUpdated` from `filters.{json,js}` |
+| `yarn strip-generated-meta <dir>` | Strip generated meta from `.txt`/`filters.json`/`filters.js` in `<dir>` in place |
 | `yarn test` | Run unit tests (`vitest run`) |
 | `yarn lint` | Run all linters (code + types + markdown) |
 | `yarn lint:code` | ESLint check (`eslint . --ext .js,.ts`) |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,6 +79,28 @@ The `yarn build` command (and `yarn build:local`) also accepts:
   files in `platforms/` and `temp/platforms/`, and remove the `version`/`timeUpdated`
   fields from every entry in `filters.json`/`filters.js`. Useful when comparing outputs between builds.
 
+### Stripping Generated Metadata
+
+`--strip-generated-meta` runs this pass as part of a build. To run the same pass
+on an existing build-output directory without recompiling, use the standalone
+command:
+
+```bash
+yarn strip-generated-meta <dir>
+```
+
+It rewrites, in place, every `.txt` filter file and every `filters.json` /
+`filters.js` under `<dir>` — dropping the generated meta lines and the
+`version` / `timeUpdated` fields, exactly as the build flag does.
+
+The directory argument is **required**. The command mutates files in place, and
+defaulting to the tracked `platforms/` tree would make it easy to strip the
+committed metadata the products read. Point it at a throwaway copy instead:
+
+```bash
+yarn strip-generated-meta temp/platforms
+```
+
 ### Generating Filter Cache
 
 To update the cached `filter.txt` files in `filters/`, used for
@@ -174,7 +196,9 @@ The following flags can be used with `yarn build` and `yarn build:local`:
   and not in `--skip`.
 - `--report=` — custom report file name (e.g., `--report='report-adguard.txt'`)
 - `--no-patches-prepare` — skip copying `platforms/` to `temp/platforms/`
-- `--strip-generated-meta` — remove volatile metadata lines from built files
+- `--strip-generated-meta` — remove generated meta lines from `.txt` files and
+  `version`/`timeUpdated` from `filters.json`/`filters.js`
+  (see [Stripping Generated Metadata](#stripping-generated-metadata))
 - `--use-cache` — build from cached `filter.txt` (same as `yarn build:local`)
 - `--generate-cache` — compile filters to update the `filter.txt` cache only
 - `--download-stats` — download each filter's `stats.json` without recompiling `filter.txt`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -76,7 +76,8 @@ The `yarn build` command (and `yarn build:local`) also accepts:
   (`yarn build:patches`) is not needed afterwards.
 - `--strip-generated-meta` — after compilation, remove generated meta lines
   (`! Checksum`, `! Diff-Path`, `! TimeUpdated`, `! Version`) from all filter
-  files in `platforms/` and `temp/platforms/`. Useful when comparing outputs between builds.
+  files in `platforms/` and `temp/platforms/`, and remove the `version`/`timeUpdated`
+  fields from every entry in `filters.json`/`filters.js`. Useful when comparing outputs between builds.
 
 ### Generating Filter Cache
 

--- a/scripts/build/__tests__/strip-generated-meta.test.ts
+++ b/scripts/build/__tests__/strip-generated-meta.test.ts
@@ -43,6 +43,33 @@ describe('stripGeneratedMetaFromDir', () => {
         await fs.rm(testDir, { recursive: true, force: true });
     });
 
+    /**
+     * Creates `<testDir>/<dirName>/platforms/cli/` and writes `content` verbatim
+     * to each of `fileNames` inside it.
+     *
+     * @param dirName - Unique sub-directory name isolating this case's tree.
+     * @param content - Exact bytes to write to every file.
+     * @param fileNames - Metadata file names to create (default: `filters.json`).
+     * @returns The `platforms` dir to pass to `stripGeneratedMetaFromDir`, plus the written file paths.
+     */
+    const writeMetadataFiles = async (
+        dirName: string,
+        content: string,
+        fileNames: string[] = ['filters.json'],
+    ): Promise<{ platformsDir: string; filePaths: string[] }> => {
+        const platformsDir = path.join(testDir, dirName, 'platforms');
+        const platformDir = path.join(platformsDir, 'cli');
+        await fs.mkdir(platformDir, { recursive: true });
+
+        const filePaths = await Promise.all(fileNames.map(async (name) => {
+            const filePath = path.join(platformDir, name);
+            await fs.writeFile(filePath, content, 'utf8');
+            return filePath;
+        }));
+
+        return { platformsDir, filePaths };
+    };
+
     it('strips generated metadata lines from .txt files', async () => {
         const modified = await stripGeneratedMetaFromDir(testDir);
 
@@ -119,9 +146,6 @@ describe('stripGeneratedMetaFromDir', () => {
     });
 
     it('strips version/timeUpdated fields from filters.json and filters.js', async () => {
-        const platformDir = path.join(testDir, 'json_root', 'platforms', 'cli');
-        await fs.mkdir(platformDir, { recursive: true });
-
         const metadata = {
             groups: [],
             tags: [],
@@ -137,21 +161,20 @@ describe('stripGeneratedMetaFromDir', () => {
             ],
         };
 
-        const jsonFilePath = path.join(platformDir, 'filters.json');
-        const jsFilePath = path.join(platformDir, 'filters.js');
         const content = JSON.stringify(metadata, null, '\t');
+        const { platformsDir, filePaths } = await writeMetadataFiles(
+            'json_root',
+            content,
+            ['filters.json', 'filters.js'],
+        );
 
-        await fs.writeFile(jsonFilePath, content, 'utf8');
-        await fs.writeFile(jsFilePath, content, 'utf8');
-
-        const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root', 'platforms'));
+        const modified = await stripGeneratedMetaFromDir(platformsDir);
 
         expect(modified).toBe(2);
 
-        const jsonContent = JSON.parse(await fs.readFile(jsonFilePath, 'utf8'));
-        const jsContent = JSON.parse(await fs.readFile(jsFilePath, 'utf8'));
+        const parsed = await Promise.all(filePaths.map(async (p) => JSON.parse(await fs.readFile(p, 'utf8'))));
 
-        [jsonContent, jsContent].forEach((data) => {
+        parsed.forEach((data) => {
             expect(data.filters[0]).not.toHaveProperty('version');
             expect(data.filters[0]).not.toHaveProperty('timeUpdated');
             expect(data.filters[0].filterId).toBe(1);
@@ -175,15 +198,10 @@ describe('stripGeneratedMetaFromDir', () => {
         ];
 
         await Promise.all(cases.map(async ({ dirName, hasTrailingNewline }) => {
-            const platformsDir = path.join(testDir, dirName, 'platforms');
-            const platformDir = path.join(platformsDir, 'cli');
-            await fs.mkdir(platformDir, { recursive: true });
-
             const serialized = JSON.stringify(metadata, null, '\t');
             const content = hasTrailingNewline ? `${serialized}\n` : serialized;
 
-            const jsonFilePath = path.join(platformDir, 'filters.json');
-            await fs.writeFile(jsonFilePath, content, 'utf8');
+            const { platformsDir, filePaths: [jsonFilePath] } = await writeMetadataFiles(dirName, content);
 
             await stripGeneratedMetaFromDir(platformsDir);
 
@@ -193,27 +211,22 @@ describe('stripGeneratedMetaFromDir', () => {
     });
 
     it('returns 0 for filters.json/filters.js with no version/timeUpdated fields', async () => {
-        const platformDir = path.join(testDir, 'json_root_clean', 'platforms', 'cli');
-        await fs.mkdir(platformDir, { recursive: true });
-
         const metadata = { groups: [], tags: [], filters: [{ filterId: 1, name: 'Test filter' }] };
-        const jsonFilePath = path.join(platformDir, 'filters.json');
-        await fs.writeFile(jsonFilePath, JSON.stringify(metadata, null, '\t'), 'utf8');
+        const { platformsDir } = await writeMetadataFiles('json_root_clean', JSON.stringify(metadata, null, '\t'));
 
-        const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root_clean', 'platforms'));
+        const modified = await stripGeneratedMetaFromDir(platformsDir);
         expect(modified).toBe(0);
     });
 
     it('throws and leaves the file untouched when filters.json contains invalid JSON', async () => {
-        const platformDir = path.join(testDir, 'json_root_invalid', 'platforms', 'cli');
-        await fs.mkdir(platformDir, { recursive: true });
-
-        const jsonFilePath = path.join(platformDir, 'filters.json');
         const invalidContent = '{ "filters": [ invalid json here';
-        await fs.writeFile(jsonFilePath, invalidContent, 'utf8');
+        const {
+            platformsDir,
+            filePaths: [jsonFilePath],
+        } = await writeMetadataFiles('json_root_invalid', invalidContent);
 
         await expect(
-            stripGeneratedMetaFromDir(path.join(testDir, 'json_root_invalid', 'platforms')),
+            stripGeneratedMetaFromDir(platformsDir),
         ).rejects.toThrow(/Failed to parse metadata file/);
 
         const contentAfter = await fs.readFile(jsonFilePath, 'utf8');
@@ -228,14 +241,13 @@ describe('stripGeneratedMetaFromDir', () => {
         ];
 
         await Promise.all(cases.map(async ({ dirName, metadata }) => {
-            const platformDir = path.join(testDir, dirName, 'platforms', 'cli');
-            await fs.mkdir(platformDir, { recursive: true });
-
-            const jsonFilePath = path.join(platformDir, 'filters.json');
             const content = JSON.stringify(metadata, null, '\t');
-            await fs.writeFile(jsonFilePath, content, 'utf8');
+            const {
+                platformsDir,
+                filePaths: [jsonFilePath],
+            } = await writeMetadataFiles(dirName, content);
 
-            const modified = await stripGeneratedMetaFromDir(path.join(testDir, dirName, 'platforms'));
+            const modified = await stripGeneratedMetaFromDir(platformsDir);
             expect(modified).toBe(0);
 
             const contentAfter = await fs.readFile(jsonFilePath, 'utf8');
@@ -244,15 +256,11 @@ describe('stripGeneratedMetaFromDir', () => {
     });
 
     it('returns 0 and leaves the file untouched when filters array entries are null or arrays', async () => {
-        const platformDir = path.join(testDir, 'json_root_bad_entries', 'platforms', 'cli');
-        await fs.mkdir(platformDir, { recursive: true });
-
         const metadata = { groups: [], tags: [], filters: [null, ['nested', 'array']] };
-        const jsonFilePath = path.join(platformDir, 'filters.json');
         const content = JSON.stringify(metadata, null, '\t');
-        await fs.writeFile(jsonFilePath, content, 'utf8');
+        const { platformsDir, filePaths: [jsonFilePath] } = await writeMetadataFiles('json_root_bad_entries', content);
 
-        const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root_bad_entries', 'platforms'));
+        const modified = await stripGeneratedMetaFromDir(platformsDir);
         expect(modified).toBe(0);
 
         const contentAfter = await fs.readFile(jsonFilePath, 'utf8');
@@ -260,15 +268,14 @@ describe('stripGeneratedMetaFromDir', () => {
     });
 
     it('returns 0 and leaves the file untouched when the filters array is empty', async () => {
-        const platformDir = path.join(testDir, 'json_root_empty_filters', 'platforms', 'cli');
-        await fs.mkdir(platformDir, { recursive: true });
-
         const metadata = { groups: [], tags: [], filters: [] };
-        const jsonFilePath = path.join(platformDir, 'filters.json');
         const content = JSON.stringify(metadata, null, '\t');
-        await fs.writeFile(jsonFilePath, content, 'utf8');
+        const {
+            platformsDir,
+            filePaths: [jsonFilePath],
+        } = await writeMetadataFiles('json_root_empty_filters', content);
 
-        const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root_empty_filters', 'platforms'));
+        const modified = await stripGeneratedMetaFromDir(platformsDir);
         expect(modified).toBe(0);
 
         const contentAfter = await fs.readFile(jsonFilePath, 'utf8');

--- a/scripts/build/__tests__/strip-generated-meta.test.ts
+++ b/scripts/build/__tests__/strip-generated-meta.test.ts
@@ -160,6 +160,38 @@ describe('stripGeneratedMetaFromDir', () => {
         });
     });
 
+    it('preserves tab indentation and trailing-newline from filters.json and filters.js', async () => {
+        const preservedFilter = { filterId: 1, name: 'Test filter' };
+        const metadata = {
+            groups: [],
+            tags: [],
+            filters: [{ ...preservedFilter, version: '2.1.8.0', timeUpdated: '2026-08-10T18:21:50+0000' }],
+        };
+        const expectedSerialized = JSON.stringify({ ...metadata, filters: [preservedFilter] }, null, '\t');
+
+        const cases = [
+            { dirName: 'json_root_raw_no_newline', hasTrailingNewline: false },
+            { dirName: 'json_root_raw_with_newline', hasTrailingNewline: true },
+        ];
+
+        await Promise.all(cases.map(async ({ dirName, hasTrailingNewline }) => {
+            const platformsDir = path.join(testDir, dirName, 'platforms');
+            const platformDir = path.join(platformsDir, 'cli');
+            await fs.mkdir(platformDir, { recursive: true });
+
+            const serialized = JSON.stringify(metadata, null, '\t');
+            const content = hasTrailingNewline ? `${serialized}\n` : serialized;
+
+            const jsonFilePath = path.join(platformDir, 'filters.json');
+            await fs.writeFile(jsonFilePath, content, 'utf8');
+
+            await stripGeneratedMetaFromDir(platformsDir);
+
+            const rawContent = await fs.readFile(jsonFilePath, 'utf8');
+            expect(rawContent).toBe(hasTrailingNewline ? `${expectedSerialized}\n` : expectedSerialized);
+        }));
+    });
+
     it('returns 0 for filters.json/filters.js with no version/timeUpdated fields', async () => {
         const platformDir = path.join(testDir, 'json_root_clean', 'platforms', 'cli');
         await fs.mkdir(platformDir, { recursive: true });

--- a/scripts/build/__tests__/strip-generated-meta.test.ts
+++ b/scripts/build/__tests__/strip-generated-meta.test.ts
@@ -187,4 +187,59 @@ describe('stripGeneratedMetaFromDir', () => {
         const contentAfter = await fs.readFile(jsonFile, 'utf8');
         expect(contentAfter).toBe(invalidContent);
     });
+
+    it('returns 0 and leaves the file untouched when the filters field is missing, null, or not an array', async () => {
+        const cases = [
+            { dirName: 'json_root_missing_filters', metadata: { groups: [], tags: [] } },
+            { dirName: 'json_root_null_filters', metadata: { groups: [], tags: [], filters: null } },
+            { dirName: 'json_root_nonarray_filters', metadata: { groups: [], tags: [], filters: 'not-an-array' } },
+        ];
+
+        await Promise.all(cases.map(async ({ dirName, metadata }) => {
+            const platformDir = path.join(testDir, dirName, 'platforms', 'cli');
+            await fs.mkdir(platformDir, { recursive: true });
+
+            const jsonFile = path.join(platformDir, 'filters.json');
+            const content = JSON.stringify(metadata, null, '\t');
+            await fs.writeFile(jsonFile, content, 'utf8');
+
+            const modified = await stripGeneratedMetaFromDir(path.join(testDir, dirName, 'platforms'));
+            expect(modified).toBe(0);
+
+            const contentAfter = await fs.readFile(jsonFile, 'utf8');
+            expect(contentAfter).toBe(content);
+        }));
+    });
+
+    it('returns 0 and leaves the file untouched when filters array entries are null or arrays', async () => {
+        const platformDir = path.join(testDir, 'json_root_bad_entries', 'platforms', 'cli');
+        await fs.mkdir(platformDir, { recursive: true });
+
+        const metadata = { groups: [], tags: [], filters: [null, ['nested', 'array']] };
+        const jsonFile = path.join(platformDir, 'filters.json');
+        const content = JSON.stringify(metadata, null, '\t');
+        await fs.writeFile(jsonFile, content, 'utf8');
+
+        const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root_bad_entries', 'platforms'));
+        expect(modified).toBe(0);
+
+        const contentAfter = await fs.readFile(jsonFile, 'utf8');
+        expect(contentAfter).toBe(content);
+    });
+
+    it('returns 0 and leaves the file untouched when the filters array is empty', async () => {
+        const platformDir = path.join(testDir, 'json_root_empty_filters', 'platforms', 'cli');
+        await fs.mkdir(platformDir, { recursive: true });
+
+        const metadata = { groups: [], tags: [], filters: [] };
+        const jsonFile = path.join(platformDir, 'filters.json');
+        const content = JSON.stringify(metadata, null, '\t');
+        await fs.writeFile(jsonFile, content, 'utf8');
+
+        const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root_empty_filters', 'platforms'));
+        expect(modified).toBe(0);
+
+        const contentAfter = await fs.readFile(jsonFile, 'utf8');
+        expect(contentAfter).toBe(content);
+    });
 });

--- a/scripts/build/__tests__/strip-generated-meta.test.ts
+++ b/scripts/build/__tests__/strip-generated-meta.test.ts
@@ -117,4 +117,58 @@ describe('stripGeneratedMetaFromDir', () => {
         expect(oldContent.includes('! Version:')).toBe(false);
         expect(oldContent.includes('||example.com^')).toBe(true);
     });
+
+    it('strips version/timeUpdated fields from filters.json and filters.js', async () => {
+        const platformDir = path.join(testDir, 'json_root', 'platforms', 'cli');
+        await fs.mkdir(platformDir, { recursive: true });
+
+        const metadata = {
+            groups: [],
+            tags: [],
+            filters: [
+                {
+                    filterId: 1,
+                    name: 'Test filter',
+                    timeAdded: '2014-06-30T07:56:55+0000',
+                    version: '2.1.8.0',
+                    timeUpdated: '2026-08-10T18:21:50+0000',
+                    deprecated: false,
+                },
+            ],
+        };
+
+        const jsonFile = path.join(platformDir, 'filters.json');
+        const jsFile = path.join(platformDir, 'filters.js');
+        const content = JSON.stringify(metadata, null, '\t');
+
+        await fs.writeFile(jsonFile, content, 'utf8');
+        await fs.writeFile(jsFile, content, 'utf8');
+
+        const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root', 'platforms'));
+
+        expect(modified).toBe(2);
+
+        const jsonContent = JSON.parse(await fs.readFile(jsonFile, 'utf8'));
+        const jsContent = JSON.parse(await fs.readFile(jsFile, 'utf8'));
+
+        [jsonContent, jsContent].forEach((data) => {
+            expect(data.filters[0]).not.toHaveProperty('version');
+            expect(data.filters[0]).not.toHaveProperty('timeUpdated');
+            expect(data.filters[0].filterId).toBe(1);
+            expect(data.filters[0].name).toBe('Test filter');
+            expect(data.filters[0].timeAdded).toBe('2014-06-30T07:56:55+0000');
+        });
+    });
+
+    it('returns 0 for filters.json/filters.js with no version/timeUpdated fields', async () => {
+        const platformDir = path.join(testDir, 'json_root_clean', 'platforms', 'cli');
+        await fs.mkdir(platformDir, { recursive: true });
+
+        const metadata = { groups: [], tags: [], filters: [{ filterId: 1, name: 'Test filter' }] };
+        const jsonFile = path.join(platformDir, 'filters.json');
+        await fs.writeFile(jsonFile, JSON.stringify(metadata, null, '\t'), 'utf8');
+
+        const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root_clean', 'platforms'));
+        expect(modified).toBe(0);
+    });
 });

--- a/scripts/build/__tests__/strip-generated-meta.test.ts
+++ b/scripts/build/__tests__/strip-generated-meta.test.ts
@@ -255,18 +255,6 @@ describe('stripGeneratedMetaFromDir', () => {
         }));
     });
 
-    it('returns 0 and leaves the file untouched when filters array entries are null or arrays', async () => {
-        const metadata = { groups: [], tags: [], filters: [null, ['nested', 'array']] };
-        const content = JSON.stringify(metadata, null, '\t');
-        const { platformsDir, filePaths: [jsonFilePath] } = await writeMetadataFiles('json_root_bad_entries', content);
-
-        const modified = await stripGeneratedMetaFromDir(platformsDir);
-        expect(modified).toBe(0);
-
-        const contentAfter = await fs.readFile(jsonFilePath, 'utf8');
-        expect(contentAfter).toBe(content);
-    });
-
     it('returns 0 and leaves the file untouched when the filters array is empty', async () => {
         const metadata = { groups: [], tags: [], filters: [] };
         const content = JSON.stringify(metadata, null, '\t');

--- a/scripts/build/__tests__/strip-generated-meta.test.ts
+++ b/scripts/build/__tests__/strip-generated-meta.test.ts
@@ -13,14 +13,14 @@ import { stripGeneratedMetaFromDir } from '../strip-generated-meta.js';
 describe('stripGeneratedMetaFromDir', () => {
     let testDir: string;
     let filtersDir: string;
-    let testFile: string;
+    let testFilePath: string;
 
     beforeAll(async () => {
         // Create a temporary directory structure mimicking the project layout
         testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'strip-meta-test-'));
         filtersDir = path.join(testDir, 'filters');
         await fs.mkdir(filtersDir);
-        testFile = path.join(filtersDir, 'test.txt');
+        testFilePath = path.join(filtersDir, 'test.txt');
 
         // Create a test file with generated metadata lines
         const content = [
@@ -35,7 +35,7 @@ describe('stripGeneratedMetaFromDir', () => {
             '',
         ].join('\n');
 
-        await fs.writeFile(testFile, content, 'utf8');
+        await fs.writeFile(testFilePath, content, 'utf8');
     });
 
     afterAll(async () => {
@@ -75,7 +75,7 @@ describe('stripGeneratedMetaFromDir', () => {
 
         expect(modified).toBe(1);
 
-        const content = await fs.readFile(testFile, 'utf8');
+        const content = await fs.readFile(testFilePath, 'utf8');
         const lines = content.split('\n');
 
         // Generated meta lines should be removed
@@ -239,11 +239,12 @@ describe('stripGeneratedMetaFromDir', () => {
         expect(contentAfter).toBe(invalidContent);
     });
 
-    it('returns 0 and leaves the file untouched when the filters field is missing, null, or not an array', async () => {
+    it('returns 0 and leaves the file untouched when filters is missing, null, non-array, or empty', async () => {
         const cases = [
             { dirName: 'json_root_missing_filters', metadata: { groups: [], tags: [] } },
             { dirName: 'json_root_null_filters', metadata: { groups: [], tags: [], filters: null } },
             { dirName: 'json_root_nonarray_filters', metadata: { groups: [], tags: [], filters: 'not-an-array' } },
+            { dirName: 'json_root_empty_filters', metadata: { groups: [], tags: [], filters: [] } },
         ];
 
         await Promise.all(cases.map(async ({ dirName, metadata }) => {
@@ -259,20 +260,5 @@ describe('stripGeneratedMetaFromDir', () => {
             const contentAfter = await fs.readFile(jsonFilePath, 'utf8');
             expect(contentAfter).toBe(content);
         }));
-    });
-
-    it('returns 0 and leaves the file untouched when the filters array is empty', async () => {
-        const metadata = { groups: [], tags: [], filters: [] };
-        const content = JSON.stringify(metadata, null, '\t');
-        const {
-            platformsDir,
-            filePaths: [jsonFilePath],
-        } = await writeMetadataFiles('json_root_empty_filters', content);
-
-        const modified = await stripGeneratedMetaFromDir(platformsDir);
-        expect(modified).toBe(0);
-
-        const contentAfter = await fs.readFile(jsonFilePath, 'utf8');
-        expect(contentAfter).toBe(content);
     });
 });

--- a/scripts/build/__tests__/strip-generated-meta.test.ts
+++ b/scripts/build/__tests__/strip-generated-meta.test.ts
@@ -200,13 +200,19 @@ describe('stripGeneratedMetaFromDir', () => {
         await Promise.all(cases.map(async ({ dirName, hasTrailingNewline }) => {
             const serialized = JSON.stringify(metadata, null, '\t');
             const content = hasTrailingNewline ? `${serialized}\n` : serialized;
+            const expected = hasTrailingNewline ? `${expectedSerialized}\n` : expectedSerialized;
 
-            const { platformsDir, filePaths: [jsonFilePath] } = await writeMetadataFiles(dirName, content);
+            const { platformsDir, filePaths } = await writeMetadataFiles(
+                dirName,
+                content,
+                ['filters.json', 'filters.js'],
+            );
 
             await stripGeneratedMetaFromDir(platformsDir);
 
-            const rawContent = await fs.readFile(jsonFilePath, 'utf8');
-            expect(rawContent).toBe(hasTrailingNewline ? `${expectedSerialized}\n` : expectedSerialized);
+            await Promise.all(filePaths.map(async (filePath) => {
+                expect(await fs.readFile(filePath, 'utf8')).toBe(expected);
+            }));
         }));
     });
 

--- a/scripts/build/__tests__/strip-generated-meta.test.ts
+++ b/scripts/build/__tests__/strip-generated-meta.test.ts
@@ -75,10 +75,10 @@ describe('stripGeneratedMetaFromDir', () => {
         // - old baseline copy (temp/platforms/)
         // and both need to be stripped consistently.
 
-        const oldRoot = path.join(testDir, 'old_root', 'platforms');
-        const newRoot = path.join(testDir, 'new_root', 'platforms');
-        const oldDir = path.join(oldRoot, 'filters');
-        const newDir = path.join(newRoot, 'filters');
+        const oldRootDir = path.join(testDir, 'old_root', 'platforms');
+        const newRootDir = path.join(testDir, 'new_root', 'platforms');
+        const oldDir = path.join(oldRootDir, 'filters');
+        const newDir = path.join(newRootDir, 'filters');
 
         await fs.mkdir(oldDir, { recursive: true });
         await fs.mkdir(newDir, { recursive: true });
@@ -93,22 +93,22 @@ describe('stripGeneratedMetaFromDir', () => {
             '',
         ].join('\n');
 
-        const oldFile = path.join(oldDir, 'test.txt');
-        const newFile = path.join(newDir, 'test.txt');
+        const oldFilePath = path.join(oldDir, 'test.txt');
+        const newFilePath = path.join(newDir, 'test.txt');
 
-        await fs.writeFile(oldFile, content, 'utf8');
-        await fs.writeFile(newFile, content, 'utf8');
+        await fs.writeFile(oldFilePath, content, 'utf8');
+        await fs.writeFile(newFilePath, content, 'utf8');
 
         // Strip from both directories as build.js does when --strip-generated-meta is set
-        const newCount = await stripGeneratedMetaFromDir(newRoot);
-        const oldCount = await stripGeneratedMetaFromDir(oldRoot);
+        const newCount = await stripGeneratedMetaFromDir(newRootDir);
+        const oldCount = await stripGeneratedMetaFromDir(oldRootDir);
 
         expect(newCount).toBe(1);
         expect(oldCount).toBe(1);
 
         // Verify both files are identically stripped
-        const oldContent = await fs.readFile(oldFile, 'utf8');
-        const newContent = await fs.readFile(newFile, 'utf8');
+        const oldContent = await fs.readFile(oldFilePath, 'utf8');
+        const newContent = await fs.readFile(newFilePath, 'utf8');
 
         expect(oldContent).toBe(newContent);
         expect(oldContent.includes('! Checksum:')).toBe(false);
@@ -137,19 +137,19 @@ describe('stripGeneratedMetaFromDir', () => {
             ],
         };
 
-        const jsonFile = path.join(platformDir, 'filters.json');
-        const jsFile = path.join(platformDir, 'filters.js');
+        const jsonFilePath = path.join(platformDir, 'filters.json');
+        const jsFilePath = path.join(platformDir, 'filters.js');
         const content = JSON.stringify(metadata, null, '\t');
 
-        await fs.writeFile(jsonFile, content, 'utf8');
-        await fs.writeFile(jsFile, content, 'utf8');
+        await fs.writeFile(jsonFilePath, content, 'utf8');
+        await fs.writeFile(jsFilePath, content, 'utf8');
 
         const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root', 'platforms'));
 
         expect(modified).toBe(2);
 
-        const jsonContent = JSON.parse(await fs.readFile(jsonFile, 'utf8'));
-        const jsContent = JSON.parse(await fs.readFile(jsFile, 'utf8'));
+        const jsonContent = JSON.parse(await fs.readFile(jsonFilePath, 'utf8'));
+        const jsContent = JSON.parse(await fs.readFile(jsFilePath, 'utf8'));
 
         [jsonContent, jsContent].forEach((data) => {
             expect(data.filters[0]).not.toHaveProperty('version');
@@ -197,8 +197,8 @@ describe('stripGeneratedMetaFromDir', () => {
         await fs.mkdir(platformDir, { recursive: true });
 
         const metadata = { groups: [], tags: [], filters: [{ filterId: 1, name: 'Test filter' }] };
-        const jsonFile = path.join(platformDir, 'filters.json');
-        await fs.writeFile(jsonFile, JSON.stringify(metadata, null, '\t'), 'utf8');
+        const jsonFilePath = path.join(platformDir, 'filters.json');
+        await fs.writeFile(jsonFilePath, JSON.stringify(metadata, null, '\t'), 'utf8');
 
         const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root_clean', 'platforms'));
         expect(modified).toBe(0);
@@ -208,15 +208,15 @@ describe('stripGeneratedMetaFromDir', () => {
         const platformDir = path.join(testDir, 'json_root_invalid', 'platforms', 'cli');
         await fs.mkdir(platformDir, { recursive: true });
 
-        const jsonFile = path.join(platformDir, 'filters.json');
+        const jsonFilePath = path.join(platformDir, 'filters.json');
         const invalidContent = '{ "filters": [ invalid json here';
-        await fs.writeFile(jsonFile, invalidContent, 'utf8');
+        await fs.writeFile(jsonFilePath, invalidContent, 'utf8');
 
         await expect(
             stripGeneratedMetaFromDir(path.join(testDir, 'json_root_invalid', 'platforms')),
         ).rejects.toThrow(/Failed to parse metadata file/);
 
-        const contentAfter = await fs.readFile(jsonFile, 'utf8');
+        const contentAfter = await fs.readFile(jsonFilePath, 'utf8');
         expect(contentAfter).toBe(invalidContent);
     });
 
@@ -231,14 +231,14 @@ describe('stripGeneratedMetaFromDir', () => {
             const platformDir = path.join(testDir, dirName, 'platforms', 'cli');
             await fs.mkdir(platformDir, { recursive: true });
 
-            const jsonFile = path.join(platformDir, 'filters.json');
+            const jsonFilePath = path.join(platformDir, 'filters.json');
             const content = JSON.stringify(metadata, null, '\t');
-            await fs.writeFile(jsonFile, content, 'utf8');
+            await fs.writeFile(jsonFilePath, content, 'utf8');
 
             const modified = await stripGeneratedMetaFromDir(path.join(testDir, dirName, 'platforms'));
             expect(modified).toBe(0);
 
-            const contentAfter = await fs.readFile(jsonFile, 'utf8');
+            const contentAfter = await fs.readFile(jsonFilePath, 'utf8');
             expect(contentAfter).toBe(content);
         }));
     });
@@ -248,14 +248,14 @@ describe('stripGeneratedMetaFromDir', () => {
         await fs.mkdir(platformDir, { recursive: true });
 
         const metadata = { groups: [], tags: [], filters: [null, ['nested', 'array']] };
-        const jsonFile = path.join(platformDir, 'filters.json');
+        const jsonFilePath = path.join(platformDir, 'filters.json');
         const content = JSON.stringify(metadata, null, '\t');
-        await fs.writeFile(jsonFile, content, 'utf8');
+        await fs.writeFile(jsonFilePath, content, 'utf8');
 
         const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root_bad_entries', 'platforms'));
         expect(modified).toBe(0);
 
-        const contentAfter = await fs.readFile(jsonFile, 'utf8');
+        const contentAfter = await fs.readFile(jsonFilePath, 'utf8');
         expect(contentAfter).toBe(content);
     });
 
@@ -264,14 +264,14 @@ describe('stripGeneratedMetaFromDir', () => {
         await fs.mkdir(platformDir, { recursive: true });
 
         const metadata = { groups: [], tags: [], filters: [] };
-        const jsonFile = path.join(platformDir, 'filters.json');
+        const jsonFilePath = path.join(platformDir, 'filters.json');
         const content = JSON.stringify(metadata, null, '\t');
-        await fs.writeFile(jsonFile, content, 'utf8');
+        await fs.writeFile(jsonFilePath, content, 'utf8');
 
         const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root_empty_filters', 'platforms'));
         expect(modified).toBe(0);
 
-        const contentAfter = await fs.readFile(jsonFile, 'utf8');
+        const contentAfter = await fs.readFile(jsonFilePath, 'utf8');
         expect(contentAfter).toBe(content);
     });
 });

--- a/scripts/build/__tests__/strip-generated-meta.test.ts
+++ b/scripts/build/__tests__/strip-generated-meta.test.ts
@@ -171,4 +171,20 @@ describe('stripGeneratedMetaFromDir', () => {
         const modified = await stripGeneratedMetaFromDir(path.join(testDir, 'json_root_clean', 'platforms'));
         expect(modified).toBe(0);
     });
+
+    it('throws and leaves the file untouched when filters.json contains invalid JSON', async () => {
+        const platformDir = path.join(testDir, 'json_root_invalid', 'platforms', 'cli');
+        await fs.mkdir(platformDir, { recursive: true });
+
+        const jsonFile = path.join(platformDir, 'filters.json');
+        const invalidContent = '{ "filters": [ invalid json here';
+        await fs.writeFile(jsonFile, invalidContent, 'utf8');
+
+        await expect(
+            stripGeneratedMetaFromDir(path.join(testDir, 'json_root_invalid', 'platforms')),
+        ).rejects.toThrow(/Failed to parse metadata file/);
+
+        const contentAfter = await fs.readFile(jsonFile, 'utf8');
+        expect(contentAfter).toBe(invalidContent);
+    });
 });

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -197,7 +197,8 @@ const buildFilters = async () => {
     }
 
     // Strip generated metadata (Checksum, Diff-Path, TimeUpdated, Version)
-    // from compiled filter files so they don't pollute diff comparisons.
+    // from compiled filter files, and version/timeUpdated fields from
+    // filters.json/filters.js, so they don't pollute diff comparisons.
     if (stripGeneratedMeta) {
         const newCount = await stripGeneratedMetaFromDir(platformsPath);
         console.log(`Stripped generated meta from ${newCount} new file(s).`);

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -35,6 +35,15 @@ const isGeneratedMetaLine = (line: string): boolean => {
 };
 
 /**
+ * Checks whether an array contains only non-null objects (i.e. records).
+ * @param value - The array to check.
+ * @returns True if every item in the array is a non-null object.
+ */
+const isRecordArray = (value: unknown[]): value is Record<string, unknown>[] => {
+    return value.every((item) => typeof item === 'object' && item !== null);
+};
+
+/**
  * Strip generated version/timeUpdated fields from each entry of the `filters` array
  * in a filters.json/filters.js metadata file, in-place.
  *
@@ -54,12 +63,12 @@ const stripMetaFromMetadataFile = async (filePath: string): Promise<boolean> => 
         );
     }
 
-    if (!Array.isArray(data.filters)) {
+    if (!Array.isArray(data.filters) || !isRecordArray(data.filters)) {
         return false;
     }
 
     let modified = false;
-    data.filters.forEach((filter: Record<string, unknown>) => {
+    data.filters.forEach((filter) => {
         GENERATED_META_FIELDS.forEach((field) => {
             if (field in filter) {
                 delete filter[field];

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -36,6 +36,7 @@ const isGeneratedMetaLine = (line: string): boolean => {
 
 /**
  * Checks whether an array contains only non-null objects (i.e. records).
+ *
  * @param value - The array to check.
  * @returns True if every item in the array is a non-null object.
  */

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -43,7 +43,16 @@ const isGeneratedMetaLine = (line: string): boolean => {
  */
 const stripMetaFromMetadataFile = async (filePath: string): Promise<boolean> => {
     const content = await fs.readFile(filePath, 'utf8');
-    const data = JSON.parse(content);
+    let data: { filters?: unknown };
+
+    try {
+        data = JSON.parse(content) as { filters?: unknown };
+    } catch (error) {
+        const reason = error instanceof Error ? ` ${error.message}` : '';
+        throw new Error(
+            `Failed to parse metadata file at ${filePath}. The file must contain valid JSON.${reason}`,
+        );
+    }
 
     if (!Array.isArray(data.filters)) {
         return false;

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -80,7 +80,8 @@ const stripMetaFromMetadataFile = async (filePath: string): Promise<boolean> => 
         return false;
     }
 
-    await fs.writeFile(filePath, JSON.stringify(data, null, '\t'), 'utf8');
+    const serialized = JSON.stringify(data, null, '\t');
+    await fs.writeFile(filePath, content.endsWith('\n') ? `${serialized}\n` : serialized, 'utf8');
     return true;
 };
 

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -47,6 +47,8 @@ const isRecordArray = (value: unknown[]): value is Record<string, unknown>[] => 
  * Strip generated version/timeUpdated fields from each entry of the `filters` array
  * in a filters.json/filters.js metadata file, in-place.
  *
+ * https://github.com/AdguardTeam/FiltersRegistry/issues/1208
+ *
  * @param filePath - Absolute path to the filters.json or filters.js file.
  * @returns True if the file was modified, false otherwise.
  */

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -41,7 +41,9 @@ const isGeneratedMetaLine = (line: string): boolean => {
  * https://github.com/AdguardTeam/FiltersRegistry/issues/1208
  *
  * @param filePath - Absolute path to the filters.json or filters.js file.
- * @returns True if the file was modified, false otherwise.
+ * @returns True if a field was removed and the file rewritten; false when the
+ * parsed content is not an object, has no `filters` array, or has nothing to strip.
+ * @throws If the file is not valid JSON.
  */
 const stripMetaFromMetadataFile = async (filePath: string): Promise<boolean> => {
     const content = await fs.readFile(filePath, 'utf8');
@@ -106,10 +108,11 @@ const stripGeneratedMeta = async (filePath: string): Promise<boolean> => {
 /**
  * Single-pass recursive walk: strips metadata from .txt files inside `filters/`
  * directories, and from any `filters.json`/`filters.js` metadata files found
- * anywhere under the root, counting modified files per `filters/` dir.
+ * anywhere under the root.
  *
  * When a directory named `filters` is encountered, all .txt files inside it are
- * processed immediately — no second traversal is needed.
+ * processed immediately — no second traversal is needed. `.txt` modifications are
+ * logged as an aggregate per `filters/` dir; each metadata file is logged on its own.
  *
  * @param dir - Current directory being walked.
  * @param rootDir - Top-level root (used only for log output).

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -35,16 +35,6 @@ const isGeneratedMetaLine = (line: string): boolean => {
 };
 
 /**
- * Checks whether an array contains only non-null objects (i.e. records).
- *
- * @param value - The array to check.
- * @returns True if every item in the array is a non-null object.
- */
-const isRecordArray = (value: unknown[]): value is Record<string, unknown>[] => {
-    return value.every((item) => typeof item === 'object' && item !== null && !Array.isArray(item));
-};
-
-/**
  * Strip generated version/timeUpdated fields from each entry of the `filters` array
  * in a filters.json/filters.js metadata file, in-place.
  *
@@ -69,9 +59,9 @@ const stripMetaFromMetadataFile = async (filePath: string): Promise<boolean> => 
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
         return false;
     }
-    const data = parsed as { filters?: unknown };
+    const data = parsed as { filters?: Record<string, unknown>[] };
 
-    if (!Array.isArray(data.filters) || !isRecordArray(data.filters)) {
+    if (!Array.isArray(data.filters)) {
         return false;
     }
 

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -164,24 +164,27 @@ export const stripGeneratedMetaFromDir = async (rootDir: string): Promise<number
     return walkAndStrip(rootDir, rootDir);
 };
 
-// CLI entrypoint: strip generated meta from platform build outputs when run directly
+// CLI entrypoint: strip generated meta from a build-output dir when run directly.
+// The target must be explicit — this rewrites files in place, and the tracked
+// `platforms/` tree is a tempting default that would ship stripped metadata.
 if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
-    const rootDirs = process.argv[2]
-        ? [path.resolve(process.argv[2])]
-        : [path.resolve('platforms'), path.resolve('temp', 'platforms')];
+    const target = process.argv[2];
+    if (!target) {
+        // eslint-disable-next-line no-console
+        console.error('Usage: strip-generated-meta <dir>   (e.g. temp/platforms)');
+        // eslint-disable-next-line no-console
+        console.error('Rewrites .txt / filters.json / filters.js under <dir> in place.');
+        process.exit(1);
+    }
 
-    const results = await Promise.all(
-        rootDirs
-            .filter((dir) => existsSync(dir))
-            .map(async (rootDir) => {
-                const count = await stripGeneratedMetaFromDir(rootDir);
-                // eslint-disable-next-line no-console
-                console.log(`${path.relative('.', rootDir)}: ${count} file(s) modified.`);
-                return count;
-            }),
-    );
+    const rootDir = path.resolve(target);
+    if (!existsSync(rootDir)) {
+        // eslint-disable-next-line no-console
+        console.error(`strip-generated-meta: no such directory: ${rootDir}`);
+        process.exit(1);
+    }
 
-    const total = results.reduce((sum, count) => sum + count, 0);
+    const total = await stripGeneratedMetaFromDir(rootDir);
     // eslint-disable-next-line no-console
-    console.log(`Done. ${total} file(s) modified in total.`);
+    console.log(`Done. ${total} file(s) modified in ${path.relative('.', rootDir) || '.'}.`);
 }

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -129,12 +129,12 @@ const walkAndStrip = async (dir: string, rootDir: string): Promise<number> => {
                 return (await stripGeneratedMeta(fullPath)) ? 1 : 0;
             }
             if (METADATA_FILE_NAMES.includes(entry.name)) {
-                if (await stripMetaFromMetadataFile(fullPath)) {
+                const stripped = await stripMetaFromMetadataFile(fullPath);
+                if (stripped) {
                     // eslint-disable-next-line no-console
                     console.log(`${path.relative(rootDir, fullPath)}: stripped generated meta fields`);
-                    return 1;
                 }
-                return 0;
+                return stripped ? 1 : 0;
             }
             return 0;
         }

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -132,7 +132,7 @@ const walkAndStrip = async (dir: string, rootDir: string): Promise<number> => {
                 const stripped = await stripMetaFromMetadataFile(fullPath);
                 if (stripped) {
                     // eslint-disable-next-line no-console
-                    console.log(`${path.relative(rootDir, fullPath)}: stripped generated meta fields`);
+                    console.log(`${path.relative(rootDir, fullPath)}: stripped generated meta`);
                 }
                 return stripped ? 1 : 0;
             }
@@ -144,7 +144,7 @@ const walkAndStrip = async (dir: string, rootDir: string): Promise<number> => {
             const modified = await walkAndStrip(fullPath, rootDir);
             if (modified > 0) {
                 // eslint-disable-next-line no-console
-                console.log(`${path.relative(rootDir, fullPath)}: stripped metadata from ${modified} file(s)`);
+                console.log(`${path.relative(rootDir, fullPath)}: stripped generated meta from ${modified} file(s)`);
             }
             return modified;
         }

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -52,11 +52,17 @@ const isRecordArray = (value: unknown[]): value is Record<string, unknown>[] => 
  */
 const stripMetaFromMetadataFile = async (filePath: string): Promise<boolean> => {
     const content = await fs.readFile(filePath, 'utf8');
-    if (typeof content !== 'string' ) {
-        return false;
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(content);
+    } catch (error) {
+        const reason = error instanceof Error ? ` ${error.message}` : '';
+        throw new Error(
+            `Failed to parse metadata file at ${filePath}. The file must contain valid JSON.${reason}`,
+        );
     }
 
-    const parsed = JSON.parse(content) as unknown;
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
         return false;
     }

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 
 const FILTERS_DIR_NAME = 'filters';
 const TXT_FILE_EXTENSION = '.txt';
-const METADATA_FILE_NAMES = ['filters.json', 'filters.js'];
+const METADATA_FILE_NAMES: readonly string[] = ['filters.json', 'filters.js'];
 
 /**
  * Lines starting with these prefixes are generated meta — they change on every build

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -52,16 +52,15 @@ const isRecordArray = (value: unknown[]): value is Record<string, unknown>[] => 
  */
 const stripMetaFromMetadataFile = async (filePath: string): Promise<boolean> => {
     const content = await fs.readFile(filePath, 'utf8');
-    let data: { filters?: unknown };
-
-    try {
-        data = JSON.parse(content) as { filters?: unknown };
-    } catch (error) {
-        const reason = error instanceof Error ? ` ${error.message}` : '';
-        throw new Error(
-            `Failed to parse metadata file at ${filePath}. The file must contain valid JSON.${reason}`,
-        );
+    if (typeof content !== 'string' ) {
+        return false;
     }
+
+    const parsed = JSON.parse(content) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+        return false;
+    }
+    const data = parsed as { filters?: unknown };
 
     if (!Array.isArray(data.filters) || !isRecordArray(data.filters)) {
         return false;

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -135,7 +135,12 @@ const walkAndStrip = async (dir: string, rootDir: string): Promise<number> => {
                 return (await stripGeneratedMeta(fullPath)) ? 1 : 0;
             }
             if (METADATA_FILE_NAMES.includes(entry.name)) {
-                return (await stripMetaFromMetadataFile(fullPath)) ? 1 : 0;
+                if (await stripMetaFromMetadataFile(fullPath)) {
+                    // eslint-disable-next-line no-console
+                    console.log(`${path.relative(rootDir, fullPath)}: stripped generated meta fields`);
+                    return 1;
+                }
+                return 0;
             }
             return 0;
         }

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 
 const FILTERS_DIR_NAME = 'filters';
 const TXT_FILE_EXTENSION = '.txt';
+const METADATA_FILE_NAMES = ['filters.json', 'filters.js'];
 
 /**
  * Lines starting with these prefixes are generated meta — they change on every build
@@ -18,6 +19,12 @@ const GENERATED_META_PREFIXES = [
 ] as const;
 
 /**
+ * Fields inside each entry of the `filters` array in filters.json/filters.js that are
+ * generated meta — same rationale as GENERATED_META_PREFIXES, but for the JSON metadata files.
+ */
+const GENERATED_META_FIELDS = ['version', 'timeUpdated'] as const;
+
+/**
  * Checks whether a line is a generated meta line that should be stripped.
  *
  * @param line - A single line from a filter file.
@@ -25,6 +32,39 @@ const GENERATED_META_PREFIXES = [
  */
 const isGeneratedMetaLine = (line: string): boolean => {
     return GENERATED_META_PREFIXES.some((prefix) => line.startsWith(prefix));
+};
+
+/**
+ * Strip generated version/timeUpdated fields from each entry of the `filters` array
+ * in a filters.json/filters.js metadata file, in-place.
+ *
+ * @param filePath - Absolute path to the filters.json or filters.js file.
+ * @returns True if the file was modified, false otherwise.
+ */
+const stripMetaFromMetadataFile = async (filePath: string): Promise<boolean> => {
+    const content = await fs.readFile(filePath, 'utf8');
+    const data = JSON.parse(content);
+
+    if (!Array.isArray(data.filters)) {
+        return false;
+    }
+
+    let modified = false;
+    data.filters.forEach((filter: Record<string, unknown>) => {
+        GENERATED_META_FIELDS.forEach((field) => {
+            if (field in filter) {
+                delete filter[field];
+                modified = true;
+            }
+        });
+    });
+
+    if (!modified) {
+        return false;
+    }
+
+    await fs.writeFile(filePath, JSON.stringify(data, null, '\t'), 'utf8');
+    return true;
 };
 
 /**
@@ -48,7 +88,8 @@ const stripGeneratedMeta = async (filePath: string): Promise<boolean> => {
 
 /**
  * Single-pass recursive walk: strips metadata from .txt files inside `filters/`
- * directories and counts modified files per `filters/` dir.
+ * directories, and from any `filters.json`/`filters.js` metadata files found
+ * anywhere under the root, counting modified files per `filters/` dir.
  *
  * When a directory named `filters` is encountered, all .txt files inside it are
  * processed immediately — no second traversal is needed.
@@ -64,10 +105,11 @@ const walkAndStrip = async (dir: string, rootDir: string): Promise<number> => {
         const fullPath = path.join(dir, entry.name);
 
         if (!entry.isDirectory()) {
-            // Only process .txt files that are directly inside a `filters/` dir,
-            // which is guaranteed by the caller when dir itself is a filters dir.
             if (entry.name.endsWith(TXT_FILE_EXTENSION)) {
                 return (await stripGeneratedMeta(fullPath)) ? 1 : 0;
+            }
+            if (METADATA_FILE_NAMES.includes(entry.name)) {
+                return (await stripMetaFromMetadataFile(fullPath)) ? 1 : 0;
             }
             return 0;
         }
@@ -90,7 +132,8 @@ const walkAndStrip = async (dir: string, rootDir: string): Promise<number> => {
 
 /**
  * Strip generated metadata lines from all .txt files inside all `filters/`
- * directories found recursively under the given root.
+ * directories, and generated version/timeUpdated fields from all
+ * `filters.json`/`filters.js` files, found recursively under the given root.
  *
  * @param rootDir - Root directory to search (e.g. `platforms/`).
  * @returns Number of files actually modified.

--- a/scripts/build/strip-generated-meta.ts
+++ b/scripts/build/strip-generated-meta.ts
@@ -40,7 +40,7 @@ const isGeneratedMetaLine = (line: string): boolean => {
  * @returns True if every item in the array is a non-null object.
  */
 const isRecordArray = (value: unknown[]): value is Record<string, unknown>[] => {
-    return value.every((item) => typeof item === 'object' && item !== null);
+    return value.every((item) => typeof item === 'object' && item !== null && !Array.isArray(item));
 };
 
 /**

--- a/scripts/compare-build-output-against-master.sh
+++ b/scripts/compare-build-output-against-master.sh
@@ -361,18 +361,18 @@ generate_report() {
         "$PLATFORMS_MASTER" "$PLATFORMS_CHANGED" \
         | grep -cE "filters\.(json|js)" || true)
 
-    echo "${C_BOLD}--- Rule Files ---${C_RESET}"
-    echo "Total .txt files compared: $total"
-    echo "Files with diffs:          $rule_diffs"
-    [ -n "$diff_list" ] && printf '%b\n' "$diff_list"
-    echo ""
-    echo "${C_BOLD}--- Metadata Files (informational) ---${C_RESET}"
-    echo "filters.json/filters.js diffs: $meta_diffs  (version counter noise, not a regression)"
-    echo ""
-    echo "${C_BOLD}--- Verdict ---${C_RESET}"
-    [ "$rule_diffs" -eq 0 ] \
-        && echo "${C_GREEN}${CHECK} PASS${C_RESET} — no rule file diffs" \
-        || { echo "${C_RED}${CROSS} FAIL${C_RESET} — $rule_diffs rule file(s) differ"; return 1; }
+  echo "${C_BOLD}--- Rule Files ---${C_RESET}"
+  echo "Total .txt files compared: $total"
+  echo "Files with diffs:          $rule_diffs"
+  [ -n "$diff_list" ] && printf "$diff_list\n"
+  echo ""
+  echo "${C_BOLD}--- Metadata Files (informational) ---${C_RESET}"
+  echo "filters.json/filters.js diffs: $meta_diffs (a nonzero count here signals a metadata change)"
+  echo ""
+  echo "${C_BOLD}--- Verdict ---${C_RESET}"
+  [ "$rule_diffs" -eq 0 ] \
+    && echo "${C_GREEN}${CHECK} PASS${C_RESET} — no rule file diffs" \
+    || { echo "${C_RED}${CROSS} FAIL${C_RESET} — $rule_diffs rule file(s) differ"; return 1; }
 }
 
 # --- Step 0: reuse existing build output, if any ---

--- a/scripts/compare-build-output-against-master.sh
+++ b/scripts/compare-build-output-against-master.sh
@@ -366,13 +366,19 @@ generate_report() {
   echo "Files with diffs:          $rule_diffs"
   [ -n "$diff_list" ] && printf "$diff_list\n"
   echo ""
-  echo "${C_BOLD}--- Metadata Files (informational) ---${C_RESET}"
-  echo "filters.json/filters.js diffs: $meta_diffs (a nonzero count here signals a metadata change)"
+  echo "${C_BOLD}--- Metadata Files ---${C_RESET}"
+  echo "filters.json/filters.js diffs: $meta_diffs"
   echo ""
   echo "${C_BOLD}--- Verdict ---${C_RESET}"
-  [ "$rule_diffs" -eq 0 ] \
-    && echo "${C_GREEN}${CHECK} PASS${C_RESET} — no rule file diffs" \
-    || { echo "${C_RED}${CROSS} FAIL${C_RESET} — $rule_diffs rule file(s) differ"; return 1; }
+  if [ "$rule_diffs" -eq 0 ] && [ "$meta_diffs" -eq 0 ]; then
+    echo "${C_GREEN}${CHECK} PASS${C_RESET} — no rule file or metadata diffs"
+  else
+    local fail_reasons=""
+    [ "$rule_diffs" -gt 0 ] && fail_reasons="$fail_reasons $rule_diffs rule file(s) differ;"
+    [ "$meta_diffs" -gt 0 ] && fail_reasons="$fail_reasons $meta_diffs metadata file(s) differ;"
+    echo "${C_RED}${CROSS} FAIL${C_RESET} —$fail_reasons"
+    return 1
+  fi
 }
 
 # --- Step 0: reuse existing build output, if any ---

--- a/scripts/compare-build-output-against-master.sh
+++ b/scripts/compare-build-output-against-master.sh
@@ -374,8 +374,8 @@ generate_report() {
     echo "${C_GREEN}${CHECK} PASS${C_RESET} — no rule file or metadata diffs"
   else
     local fail_reasons=""
-    [ "$rule_diffs" -gt 0 ] && fail_reasons="$fail_reasons $rule_diffs rule file(s) differ;"
-    [ "$meta_diffs" -gt 0 ] && fail_reasons="$fail_reasons $meta_diffs metadata file(s) differ;"
+    [ "$rule_diffs" -gt 0 ] && fail_reasons="$fail_reasons $rule_diffs rule file(s) differ"
+    [ "$meta_diffs" -gt 0 ] && fail_reasons="${fail_reasons:+$fail_reasons; }$meta_diffs metadata file(s) differ"
     echo "${C_RED}${CROSS} FAIL${C_RESET} —$fail_reasons"
     return 1
   fi

--- a/scripts/compare-build-output-against-master.sh
+++ b/scripts/compare-build-output-against-master.sh
@@ -371,24 +371,28 @@ generate_report() {
         "$PLATFORMS_MASTER" "$PLATFORMS_CHANGED" \
         | grep -cE "filters\.(json|js)" || true)
 
-  echo "${C_BOLD}--- Rule Files ---${C_RESET}"
-  echo "Total .txt files compared: $total"
-  echo "Files with diffs:          $rule_diffs"
-  [ -n "$diff_list" ] && printf "$diff_list\n"
-  echo ""
-  echo "${C_BOLD}--- Metadata Files ---${C_RESET}"
-  echo "filters.json/filters.js diffs: $meta_diffs"
-  echo ""
-  echo "${C_BOLD}--- Verdict ---${C_RESET}"
-  if [ "$rule_diffs" -eq 0 ] && [ "$meta_diffs" -eq 0 ]; then
-    echo "${C_GREEN}${CHECK} PASS${C_RESET} — no rule file or metadata diffs"
-  else
-    local fail_reasons=""
-    [ "$rule_diffs" -gt 0 ] && fail_reasons="$fail_reasons $rule_diffs rule file(s) differ"
-    [ "$meta_diffs" -gt 0 ] && fail_reasons="${fail_reasons:+$fail_reasons; }$meta_diffs metadata file(s) differ"
-    echo "${C_RED}${CROSS} FAIL${C_RESET} —$fail_reasons"
-    return 1
-  fi
+    echo "${C_BOLD}--- Rule Files ---${C_RESET}"
+    echo "Total .txt files compared: $total"
+    echo "Files with diffs:          $rule_diffs"
+    [ -n "$diff_list" ] && printf '%b\n' "$diff_list"
+    echo ""
+    echo "${C_BOLD}--- Added Files (informational) ---${C_RESET}"
+    echo "Files only on the changed side: $added_count  (new filters or platform targets, not a regression)"
+    [ -n "$added_list" ] && printf '%b\n' "$added_list"
+    echo ""
+    echo "${C_BOLD}--- Metadata Files ---${C_RESET}"
+    echo "filters.json/filters.js diffs: $meta_diffs"
+    echo ""
+    echo "${C_BOLD}--- Verdict ---${C_RESET}"
+    if [ "$rule_diffs" -eq 0 ] && [ "$meta_diffs" -eq 0 ]; then
+        echo "${C_GREEN}${CHECK} PASS${C_RESET} — no rule file or metadata diffs"
+    else
+        local fail_reasons=""
+        [ "$rule_diffs" -gt 0 ] && fail_reasons="$fail_reasons $rule_diffs rule file(s) differ"
+        [ "$meta_diffs" -gt 0 ] && fail_reasons="${fail_reasons:+$fail_reasons; }$meta_diffs metadata file(s) differ"
+        echo "${C_RED}${CROSS} FAIL${C_RESET} —$fail_reasons"
+        return 1
+    fi
 }
 
 # --- Step 0: reuse existing build output, if any ---

--- a/scripts/compare-build-output-against-master.sh
+++ b/scripts/compare-build-output-against-master.sh
@@ -366,10 +366,12 @@ generate_report() {
         fi
     done < <(find "$PLATFORMS_CHANGED" -name "*.txt" -print0)
 
-    # Secondary check — metadata
+    # Secondary check — every generated non-rule file (filters*.json/.js,
+    # local_script_rules.json). Count only "Files X and Y differ"; "Only in ..."
+    # (present on one side only) is informational like added files above.
     meta_diffs=$(diff -rq --exclude="*.txt" --exclude="*.patch" \
         "$PLATFORMS_MASTER" "$PLATFORMS_CHANGED" \
-        | grep -cE "filters\.(json|js)" || true)
+        | grep -cE '^Files .* differ$' || true)
 
     echo "${C_BOLD}--- Rule Files ---${C_RESET}"
     echo "Total .txt files compared: $total"
@@ -381,7 +383,7 @@ generate_report() {
     [ -n "$added_list" ] && printf '%b\n' "$added_list"
     echo ""
     echo "${C_BOLD}--- Metadata Files ---${C_RESET}"
-    echo "filters.json/filters.js diffs: $meta_diffs"
+    echo "Non-rule file diffs (filters.json/.js, filters_i18n.json/.js, local_script_rules.json): $meta_diffs"
     echo ""
     echo "${C_BOLD}--- Verdict ---${C_RESET}"
     if [ "$rule_diffs" -eq 0 ] && [ "$meta_diffs" -eq 0 ]; then

--- a/scripts/compare-build-output-against-master.sh
+++ b/scripts/compare-build-output-against-master.sh
@@ -387,10 +387,9 @@ generate_report() {
     if [ "$rule_diffs" -eq 0 ] && [ "$meta_diffs" -eq 0 ]; then
         echo "${C_GREEN}${CHECK} PASS${C_RESET} — no rule file or metadata diffs"
     else
-        local fail_reasons=""
-        [ "$rule_diffs" -gt 0 ] && fail_reasons="$fail_reasons $rule_diffs rule file(s) differ"
-        [ "$meta_diffs" -gt 0 ] && fail_reasons="${fail_reasons:+$fail_reasons; }$meta_diffs metadata file(s) differ"
-        echo "${C_RED}${CROSS} FAIL${C_RESET} —$fail_reasons"
+        echo "${C_RED}${CROSS} FAIL${C_RESET}"
+        [ "$rule_diffs" -gt 0 ] && echo "  $rule_diffs rule file(s) differ"
+        [ "$meta_diffs" -gt 0 ] && echo "  $meta_diffs metadata file(s) differ"
         return 1
     fi
 }


### PR DESCRIPTION
Extends `--strip-generated-meta` (previously `.txt` only) to also drop these noisy fields from compiled metadata files. Closes #1208.