### PR TITLE
Temporary enable ABP Japanese filter for CB for updating to pruned version

### DIFF
--- a/filters/ThirdParty/filter_200_ABPJapaneseFilters/metadata.json
+++ b/filters/ThirdParty/filter_200_ABPJapaneseFilters/metadata.json
@@ -12,13 +12,11 @@
     "purpose:ads",
     "purpose:privacy",
     "lang:ja",
-    "problematic",
-    "obsolete"
+    "problematic"
   ],
   "platformsExcluded": [
     "android",
     "cli",
-    "ext_android_cb",
     "ext_chromium",
     "ext_chromium_mv3",
     "ext_edge",
@@ -31,6 +29,5 @@
     "mac",
     "windows"
   ],
-  "trustLevel": "low",
-  "disabled": true
+  "trustLevel": "low"
 }


### PR DESCRIPTION
ABP Japanese filter must be pruned, because it is hardcoded and causes problems.
Revert after updating this filter to empty version in CB app.