### PR TITLE
AG-43979 Update @adguard/filters-compiler to 3.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ temp
 log.txt
 report_partial_*.txt
 Makefile
+
+.sdd/

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@adguard/agtree": "4.2.1",
         "@adguard/dead-domains-linter": "^1.0.33",
         "@adguard/diff-builder": "1.1.4",
-        "@adguard/filters-compiler": "3.3.0",
+        "@adguard/filters-compiler": "file:/tmp/filters-compiler-3.4.0.tgz",
         "add": "^2.0.6",
         "crypto-js": "^4.2.0",
         "zod": "3"


### PR DESCRIPTION
Dependency bump for the AG-43979 HTML filtering rules fix.

## Changes

- `@adguard/filters-compiler` bumped to 3.4.0 (currently referenced as a
  local tarball; to be replaced with the published version).

Dependent PRs: ext-tsurlfilter (agtree changes), ext-compiler (compiler changes).